### PR TITLE
Let binutils build on a machine with make-/texinfo >= 5

### DIFF
--- a/patches/binutils-2.14-disable-makeinfo-when-texinfo-is-too-new.patch
+++ b/patches/binutils-2.14-disable-makeinfo-when-texinfo-is-too-new.patch
@@ -1,0 +1,19 @@
+--- Makefile.in	2003-06-12 16:31:31.000000000 +0200
++++ Makefile.in	2015-09-12 21:11:42.574797570 +0200
+@@ -191,13 +191,13 @@
+ 	then echo $$r/m4/m4 ; \
+ 	else echo ${DEFAULT_M4} ; fi`
+ 
+-# For an installed makeinfo, we require it to be from texinfo 4 or
+-# higher, else we use the "missing" dummy.
++# For an installed makeinfo, we require it to be texinfo 4. texinfo >= 5 is more strict
++# and breaks the compilation. Disable makeinfo in that case by using the "missing" dummy.
+ MAKEINFO=@MAKEINFO@
+ USUAL_MAKEINFO = `if [ -f $$r/texinfo/makeinfo/makeinfo ] ; \
+ 	then echo $$r/texinfo/makeinfo/makeinfo ; \
+ 	else if (makeinfo --version \
+-	  | egrep 'texinfo[^0-9]*([1-3][0-9]|[4-9])') >/dev/null 2>&1; \
++	  | egrep 'texinfo[^0-9]*([1-3][0-9]|[4])') >/dev/null 2>&1; \
+         then echo makeinfo; else echo $$s/missing makeinfo; fi; fi`
+ 
+ # This just becomes part of the MAKEINFO definition passed down to

--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -11,6 +11,7 @@
 
  ## Enter the source directory and patch the source code.
  cd binutils-2.14 && cat ../../patches/binutils-2.14-PS2.patch | patch -p1 || { exit 1; }
+ cat ../../patches/binutils-2.14-disable-makeinfo-when-texinfo-is-too-new.patch | patch -p0 || { exit 1; }
 
  ## For each target...
  for TARGET in "ee" "iop" "dvp"; do


### PR DESCRIPTION
I was unable to build the toolchain unless i disabled the binutils doc generation.
Apparently texinfo >= 5 is stricter with the doc formatting, causing the build to fail.
This patch is a workaround by simply disabling the doc generation.