### PR TITLE
Add support for building on mac os x

### DIFF
--- a/scripts/002-gcc-3.2.3-stage1.sh
+++ b/scripts/002-gcc-3.2.3-stage1.sh
@@ -21,12 +21,16 @@
 
  ## For each target...
  for TARGET in "ee" "iop"; do
-
   ## Create and enter the build directory.
   mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
 
   ## Configure the build.
-  ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c" --with-newlib --without-headers || { exit 1; }
+  # Apple needs to pretend to be linux
+  if [ "$(uname)" == "Darwin" ]; then
+    ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --build=i386-linux-gnu --host=i386-linux-gnu --enable-languages="c" --with-newlib --without-headers || { exit 1; }
+  else
+    ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c" --with-newlib --without-headers || { exit 1; }
+  fi
 
   ## Compile and install.
   make clean && make -j 2 && make install && make clean || { exit 1; }

--- a/scripts/004-gcc-3.2.3-stage2.sh
+++ b/scripts/004-gcc-3.2.3-stage2.sh
@@ -24,8 +24,11 @@
  mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
 
  ## Configure the build.
- ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c,c++" --with-newlib --with-headers="$PS2DEV/$TARGET/$TARGET/include" || { exit 1; }
+if [ "$(uname)" == "Darwin" ]; then
+  ../configure --prefix="$PS2DEV/ee" --target="ee" --build=i386-linux-gnu --host=i386-linux-gnu --enable-languages="c,c++" --with-newlib --with-headers="$PS2DEV/ee/ee/include" --enable-cxx-flags="-G0" || { exit 1; }
+else
+  ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c,c++" --with-newlib --with-headers="$PS2DEV/$TARGET/$TARGET/include" || { exit 1; }
+fi
 
  ## Compile and install.
  make clean && make -j 2 && make install && make clean || { exit 1; }
-


### PR DESCRIPTION
We need to explicitly pretend that we are building on a linux host for the configure script to pass.