### PR TITLE
Build toolchain using all available processors

### DIFF
--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -27,7 +27,7 @@
   CFLAGS="-O0" ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
 
   ## Compile and install.
-  make clean && make -j 2 && make install && make clean || { exit 1; }
+  make clean && make -j $(nproc) && make install && make clean || { exit 1; }
 
   ## Exit the build directory.
   cd .. || { exit 1; }

--- a/scripts/002-gcc-3.2.3-stage1.sh
+++ b/scripts/002-gcc-3.2.3-stage1.sh
@@ -33,7 +33,7 @@
   fi
 
   ## Compile and install.
-  make clean && make -j 2 && make install && make clean || { exit 1; }
+  make clean && make -j $(nproc) && make install && make clean || { exit 1; }
 
   ## Exit the build directory.
   cd .. || { exit 1; }

--- a/scripts/003-newlib-1.10.0.sh
+++ b/scripts/003-newlib-1.10.0.sh
@@ -24,5 +24,5 @@
  ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
 
  ## Compile and install.
- make clean && CPPFLAGS="-G0" make -j 2 && make install && make clean || { exit 1; }
+ make clean && CPPFLAGS="-G0" make -j $(nproc) && make install && make clean || { exit 1; }
 

--- a/scripts/004-gcc-3.2.3-stage2.sh
+++ b/scripts/004-gcc-3.2.3-stage2.sh
@@ -31,4 +31,4 @@ else
 fi
 
  ## Compile and install.
- make clean && make -j 2 && make install && make clean || { exit 1; }
+ make clean && make -j $(nproc) && make install && make clean || { exit 1; }

--- a/scripts/005-ps2sdk.sh
+++ b/scripts/005-ps2sdk.sh
@@ -15,7 +15,7 @@ unset PS2SDKSRC
  fi
 
  ## Build and install
- make clean && make -j 2 && make release && make clean || { exit 1; }
+ make clean && make -j $(nproc) && make release && make clean || { exit 1; }
 
  ## Replace newlib's crt0 with the one in ps2sdk.
  ln -sf "$PS2SDK/ee/startup/crt0.o" "$PS2DEV/ee/lib/gcc-lib/ee/3.2.3/crt0.o" || { exit 1; }

--- a/scripts/006-ps2client.sh
+++ b/scripts/006-ps2client.sh
@@ -12,4 +12,4 @@
  fi
 
  ## Build and install.
- make clean && make && make install && make clean || { exit 1; }
+ make clean && make -j $(nproc) && make install && make clean || { exit 1; }


### PR DESCRIPTION
Currently, the ps2toolchain is built with a mixture between -j1 and -j2, which might not utilize all available processor cores, thus taking longer to build than necessary. This change will build all tools (binutils, GCC, newlib, PS2SDK and PS2client) with -j $(nproc), so that all available CPU cores are used.