### PR TITLE
Fix Mac build of binutils and gcc stage1

### DIFF
--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -33,7 +33,11 @@
   mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 
   ## Configure the build.
-  ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
+  if [ ${OSVER:0:6} == Darwin ]; then
+    CC=/usr/bin/gcc CXX=/usr/bin/g++ LD=/usr/bin/ld CFLAGS="-O0 -ansi -Wno-implicit-int -Wno-return-type" ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
+  else
+    ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
+  fi
 
   ## Compile and install.
   make clean && make -j $PROC_NR && make install && make clean || { exit 1; }

--- a/scripts/002-gcc-3.2.3-stage1.sh
+++ b/scripts/002-gcc-3.2.3-stage1.sh
@@ -39,7 +39,11 @@
   mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
 
   ## Configure the build.
-  ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c" --with-newlib --without-headers $TARG_XTRA_OPTS || { exit 1; }
+  if [ ${OSVER:0:6} == Darwin ]; then
+    CC=/usr/bin/gcc CXX=/usr/bin/g++ LD=/usr/bin/ld CFLAGS="-O0 -ansi -Wno-implicit-int -Wno-return-type" ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c" --with-newlib --without-headers $TARG_XTRA_OPTS || { exit 1; }
+  else
+    ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c" --with-newlib --without-headers $TARG_XTRA_OPTS || { exit 1; }
+  fi
 
   ## Compile and install.
   make clean && make -j $PROC_NR && make install && make clean || { exit 1; }


### PR DESCRIPTION
Explicitly use `/usr/bin/gcc` to avoid conflict with other installed gcc versions on Mac OS X. Also need to pass some extra CFLAGS for the build to succeed.