### PR TITLE
Disable fortify in binutils build

### DIFF
--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -40,7 +40,7 @@
   fi
 
   ## Compile and install.
-  make clean && make -j $PROC_NR && make install && make clean || { exit 1; }
+  make clean && make -j $PROC_NR CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=0" && make install && make clean || { exit 1; }
 
   ## Exit the build directory.
   cd .. || { exit 1; }


### PR DESCRIPTION
This allows later stages to be built without errors. (gcc version 5.4.0)