### PR TITLE
Fixed crash in dvp-as when using MPG 0, *.

### DIFF
--- a/patches/binutils-2.14-PS2.patch
+++ b/patches/binutils-2.14-PS2.patch
@@ -1,6 +1,6 @@
 diff -burN orig.binutils-2.14/bfd/archures.c binutils-2.14/bfd/archures.c
---- orig.binutils-2.14/bfd/archures.c	2003-04-24 09:36:06.000000000 -0300
-+++ binutils-2.14/bfd/archures.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/archures.c	2003-04-24 14:36:06.000000000 +0200
++++ binutils-2.14/bfd/archures.c	2017-03-08 00:37:47.488128372 +0100
 @@ -137,6 +137,7 @@
  .#define bfd_mach_mips5000		5000
  .#define bfd_mach_mips5400		5400
@@ -22,8 +22,8 @@ diff -burN orig.binutils-2.14/bfd/archures.c binutils-2.14/bfd/archures.c
  .#define bfd_mach_i386_i386 1
  .#define bfd_mach_i386_i8086 2
 diff -burN orig.binutils-2.14/bfd/bfd-in2.h binutils-2.14/bfd/bfd-in2.h
---- orig.binutils-2.14/bfd/bfd-in2.h	2003-05-03 13:06:57.000000000 -0300
-+++ binutils-2.14/bfd/bfd-in2.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/bfd-in2.h	2003-05-03 18:06:57.000000000 +0200
++++ binutils-2.14/bfd/bfd-in2.h	2017-03-08 00:37:47.488128372 +0100
 @@ -1605,6 +1605,7 @@
  #define bfd_mach_mips5000              5000
  #define bfd_mach_mips5400              5400
@@ -75,8 +75,8 @@ diff -burN orig.binutils-2.14/bfd/bfd-in2.h binutils-2.14/bfd/bfd-in2.h
  /* i386/elf relocations  */
    BFD_RELOC_386_GOT32,
 diff -burN orig.binutils-2.14/bfd/config.bfd binutils-2.14/bfd/config.bfd
---- orig.binutils-2.14/bfd/config.bfd	2003-06-02 17:35:20.000000000 -0300
-+++ binutils-2.14/bfd/config.bfd	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/config.bfd	2003-06-02 22:35:20.000000000 +0200
++++ binutils-2.14/bfd/config.bfd	2017-03-08 00:37:47.488128372 +0100
 @@ -63,6 +63,9 @@
  *)	         targ_archs=bfd_${targ_cpu}_arch ;;
  esac
@@ -110,8 +110,8 @@ diff -burN orig.binutils-2.14/bfd/config.bfd binutils-2.14/bfd/config.bfd
      targ_defvec=bfd_elf32_bigmips_vec
      targ_selvecs="bfd_elf32_littlemips_vec bfd_elf64_bigmips_vec bfd_elf64_littlemips_vec"
 diff -burN orig.binutils-2.14/bfd/configure binutils-2.14/bfd/configure
---- orig.binutils-2.14/bfd/configure	2003-06-12 11:25:46.000000000 -0300
-+++ binutils-2.14/bfd/configure	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/configure	2003-06-12 16:25:46.000000000 +0200
++++ binutils-2.14/bfd/configure	2017-03-08 00:37:47.491461705 +0100
 @@ -6046,6 +6046,8 @@
  done
  selvecs="$f"
@@ -122,8 +122,8 @@ diff -burN orig.binutils-2.14/bfd/configure binutils-2.14/bfd/configure
  # uniq the associated vectors in all the configured targets.
  f=""
 diff -burN orig.binutils-2.14/bfd/configure.in binutils-2.14/bfd/configure.in
---- orig.binutils-2.14/bfd/configure.in	2003-06-12 11:25:46.000000000 -0300
-+++ binutils-2.14/bfd/configure.in	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/configure.in	2003-06-12 16:25:46.000000000 +0200
++++ binutils-2.14/bfd/configure.in	2017-03-08 00:37:47.491461705 +0100
 @@ -508,6 +508,8 @@
  done
  selvecs="$f"
@@ -134,8 +134,8 @@ diff -burN orig.binutils-2.14/bfd/configure.in binutils-2.14/bfd/configure.in
  # uniq the associated vectors in all the configured targets.
  f=""
 diff -burN orig.binutils-2.14/bfd/cpu-mips.c binutils-2.14/bfd/cpu-mips.c
---- orig.binutils-2.14/bfd/cpu-mips.c	2002-12-31 03:29:25.000000000 -0400
-+++ binutils-2.14/bfd/cpu-mips.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/cpu-mips.c	2002-12-31 08:29:25.000000000 +0100
++++ binutils-2.14/bfd/cpu-mips.c	2017-03-08 00:37:47.491461705 +0100
 @@ -75,6 +75,7 @@
    I_mips5000,
    I_mips5400,
@@ -174,9 +174,121 @@ diff -burN orig.binutils-2.14/bfd/cpu-mips.c binutils-2.14/bfd/cpu-mips.c
    N (64, 64, bfd_mach_mips_sb1, "mips:sb1",       FALSE, 0),
  };
  
+diff -burN orig.binutils-2.14/bfd/elf.c binutils-2.14/bfd/elf.c
+--- orig.binutils-2.14/bfd/elf.c	2003-06-02 22:35:20.000000000 +0200
++++ binutils-2.14/bfd/elf.c	2017-03-08 00:37:47.491461705 +0100
+@@ -2214,7 +2214,7 @@
+   newsect->_raw_size = hdr->p_filesz;
+   newsect->filepos = hdr->p_offset;
+   newsect->flags |= SEC_HAS_CONTENTS;
+-  if (hdr->p_type == PT_LOAD)
++  if (hdr->p_type == PT_LOAD || hdr->p_type == PT_MIPS_IRXHDR)
+     {
+       newsect->flags |= SEC_ALLOC;
+       newsect->flags |= SEC_LOAD;
+@@ -2244,7 +2244,7 @@
+       newsect->vma = hdr->p_vaddr + hdr->p_filesz;
+       newsect->lma = hdr->p_paddr + hdr->p_filesz;
+       newsect->_raw_size = hdr->p_memsz - hdr->p_filesz;
+-      if (hdr->p_type == PT_LOAD)
++      if (hdr->p_type == PT_LOAD || hdr->p_type == PT_MIPS_IRXHDR)
+ 	{
+ 	  newsect->flags |= SEC_ALLOC;
+ 	  if (hdr->p_flags & PF_X)
+@@ -3744,7 +3744,7 @@
+       else
+ 	p->p_paddr = m->sections[0]->lma;
+ 
+-      if (p->p_type == PT_LOAD
++      if ((p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
+ 	  && (abfd->flags & D_PAGED) != 0)
+ 	p->p_align = bed->maxpagesize;
+       else if (m->count == 0)
+@@ -3765,7 +3765,7 @@
+ 	  p->p_memsz = bed->s->sizeof_ehdr;
+ 	  if (m->count > 0)
+ 	    {
+-	      BFD_ASSERT (p->p_type == PT_LOAD);
++	      BFD_ASSERT (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR);
+ 
+ 	      if (p->p_vaddr < (bfd_vma) off)
+ 		{
+@@ -3780,7 +3780,7 @@
+ 	      if (! m->p_paddr_valid)
+ 		p->p_paddr -= off;
+ 	    }
+-	  if (p->p_type == PT_LOAD)
++	  if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
+ 	    {
+ 	      filehdr_vaddr = p->p_vaddr;
+ 	      filehdr_paddr = p->p_paddr;
+@@ -3794,7 +3794,7 @@
+ 
+ 	  if (m->includes_filehdr)
+ 	    {
+-	      if (p->p_type == PT_LOAD)
++	      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
+ 		{
+ 		  phdrs_vaddr = p->p_vaddr + bed->s->sizeof_ehdr;
+ 		  phdrs_paddr = p->p_paddr + bed->s->sizeof_ehdr;
+@@ -3812,7 +3812,7 @@
+ 		    p->p_paddr -= off - p->p_offset;
+ 		}
+ 
+-	      if (p->p_type == PT_LOAD)
++	      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
+ 		{
+ 		  phdrs_vaddr = p->p_vaddr;
+ 		  phdrs_paddr = p->p_paddr;
+@@ -3825,7 +3825,7 @@
+ 	  p->p_memsz += alloc * bed->s->sizeof_phdr;
+ 	}
+ 
+-      if (p->p_type == PT_LOAD
++      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR
+ 	  || (p->p_type == PT_NOTE && bfd_get_format (abfd) == bfd_core))
+ 	{
+ 	  if (! m->includes_filehdr && ! m->includes_phdrs)
+@@ -3860,7 +3860,7 @@
+ 	      bfd_vma adjust = sec->lma - (p->p_paddr + p->p_memsz);
+ 
+ 	      p->p_memsz += adjust;
+-	      if (p->p_type == PT_LOAD
++	      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR
+ 		  || (p->p_type == PT_NOTE
+ 		      && bfd_get_format (abfd) == bfd_core))
+ 		{
+@@ -3872,7 +3872,7 @@
+ 		p->p_filesz += adjust;
+ 	    }
+ 
+-	  if (p->p_type == PT_LOAD)
++	  if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
+ 	    {
+ 	      bfd_signed_vma adjust;
+ 
+@@ -3977,7 +3977,8 @@
+ 		}
+ 
+ 	      if (align > p->p_align
+-		  && (p->p_type != PT_LOAD || (abfd->flags & D_PAGED) == 0))
++		  && ((p->p_type != PT_LOAD && p->p_type != PT_MIPS_IRXHDR)
++                  || (abfd->flags & D_PAGED) == 0))
+ 		p->p_align = align;
+ 	    }
+ 
+@@ -3998,7 +3999,7 @@
+        m != NULL;
+        m = m->next, p++)
+     {
+-      if (p->p_type != PT_LOAD && m->count > 0)
++      if (p->p_type != PT_LOAD && p->p_type != PT_MIPS_IRXHDR && m->count > 0)
+ 	{
+ 	  BFD_ASSERT (! m->includes_filehdr && ! m->includes_phdrs);
+ 	  p->p_offset = m->sections[0]->filepos;
 diff -burN orig.binutils-2.14/bfd/elf32-mips.c binutils-2.14/bfd/elf32-mips.c
---- orig.binutils-2.14/bfd/elf32-mips.c	2003-04-08 23:55:40.000000000 -0300
-+++ binutils-2.14/bfd/elf32-mips.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/elf32-mips.c	2003-04-09 04:55:40.000000000 +0200
++++ binutils-2.14/bfd/elf32-mips.c	2017-03-08 00:37:47.491461705 +0100
 @@ -75,6 +75,8 @@
    PARAMS ((bfd *, arelent *, asymbol *, PTR, asection *, bfd *, char **));
  static bfd_reloc_status_type mips16_gprel_reloc
@@ -361,121 +473,9 @@ diff -burN orig.binutils-2.14/bfd/elf32-mips.c binutils-2.14/bfd/elf32-mips.c
      case R_MIPS_GNU_VTINHERIT:
        return &elf_mips_gnu_vtinherit_howto;
      case R_MIPS_GNU_VTENTRY:
-diff -burN orig.binutils-2.14/bfd/elf.c binutils-2.14/bfd/elf.c
---- orig.binutils-2.14/bfd/elf.c	2003-06-02 17:35:20.000000000 -0300
-+++ binutils-2.14/bfd/elf.c	2007-04-29 04:00:33.000000000 -0300
-@@ -2214,7 +2214,7 @@
-   newsect->_raw_size = hdr->p_filesz;
-   newsect->filepos = hdr->p_offset;
-   newsect->flags |= SEC_HAS_CONTENTS;
--  if (hdr->p_type == PT_LOAD)
-+  if (hdr->p_type == PT_LOAD || hdr->p_type == PT_MIPS_IRXHDR)
-     {
-       newsect->flags |= SEC_ALLOC;
-       newsect->flags |= SEC_LOAD;
-@@ -2244,7 +2244,7 @@
-       newsect->vma = hdr->p_vaddr + hdr->p_filesz;
-       newsect->lma = hdr->p_paddr + hdr->p_filesz;
-       newsect->_raw_size = hdr->p_memsz - hdr->p_filesz;
--      if (hdr->p_type == PT_LOAD)
-+      if (hdr->p_type == PT_LOAD || hdr->p_type == PT_MIPS_IRXHDR)
- 	{
- 	  newsect->flags |= SEC_ALLOC;
- 	  if (hdr->p_flags & PF_X)
-@@ -3744,7 +3744,7 @@
-       else
- 	p->p_paddr = m->sections[0]->lma;
- 
--      if (p->p_type == PT_LOAD
-+      if ((p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
- 	  && (abfd->flags & D_PAGED) != 0)
- 	p->p_align = bed->maxpagesize;
-       else if (m->count == 0)
-@@ -3765,7 +3765,7 @@
- 	  p->p_memsz = bed->s->sizeof_ehdr;
- 	  if (m->count > 0)
- 	    {
--	      BFD_ASSERT (p->p_type == PT_LOAD);
-+	      BFD_ASSERT (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR);
- 
- 	      if (p->p_vaddr < (bfd_vma) off)
- 		{
-@@ -3780,7 +3780,7 @@
- 	      if (! m->p_paddr_valid)
- 		p->p_paddr -= off;
- 	    }
--	  if (p->p_type == PT_LOAD)
-+	  if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
- 	    {
- 	      filehdr_vaddr = p->p_vaddr;
- 	      filehdr_paddr = p->p_paddr;
-@@ -3794,7 +3794,7 @@
- 
- 	  if (m->includes_filehdr)
- 	    {
--	      if (p->p_type == PT_LOAD)
-+	      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
- 		{
- 		  phdrs_vaddr = p->p_vaddr + bed->s->sizeof_ehdr;
- 		  phdrs_paddr = p->p_paddr + bed->s->sizeof_ehdr;
-@@ -3812,7 +3812,7 @@
- 		    p->p_paddr -= off - p->p_offset;
- 		}
- 
--	      if (p->p_type == PT_LOAD)
-+	      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
- 		{
- 		  phdrs_vaddr = p->p_vaddr;
- 		  phdrs_paddr = p->p_paddr;
-@@ -3825,7 +3825,7 @@
- 	  p->p_memsz += alloc * bed->s->sizeof_phdr;
- 	}
- 
--      if (p->p_type == PT_LOAD
-+      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR
- 	  || (p->p_type == PT_NOTE && bfd_get_format (abfd) == bfd_core))
- 	{
- 	  if (! m->includes_filehdr && ! m->includes_phdrs)
-@@ -3860,7 +3860,7 @@
- 	      bfd_vma adjust = sec->lma - (p->p_paddr + p->p_memsz);
- 
- 	      p->p_memsz += adjust;
--	      if (p->p_type == PT_LOAD
-+	      if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR
- 		  || (p->p_type == PT_NOTE
- 		      && bfd_get_format (abfd) == bfd_core))
- 		{
-@@ -3872,7 +3872,7 @@
- 		p->p_filesz += adjust;
- 	    }
- 
--	  if (p->p_type == PT_LOAD)
-+	  if (p->p_type == PT_LOAD || p->p_type == PT_MIPS_IRXHDR)
- 	    {
- 	      bfd_signed_vma adjust;
- 
-@@ -3977,7 +3977,8 @@
- 		}
- 
- 	      if (align > p->p_align
--		  && (p->p_type != PT_LOAD || (abfd->flags & D_PAGED) == 0))
-+		  && ((p->p_type != PT_LOAD && p->p_type != PT_MIPS_IRXHDR)
-+                  || (abfd->flags & D_PAGED) == 0))
- 		p->p_align = align;
- 	    }
- 
-@@ -3998,7 +3999,7 @@
-        m != NULL;
-        m = m->next, p++)
-     {
--      if (p->p_type != PT_LOAD && m->count > 0)
-+      if (p->p_type != PT_LOAD && p->p_type != PT_MIPS_IRXHDR && m->count > 0)
- 	{
- 	  BFD_ASSERT (! m->includes_filehdr && ! m->includes_phdrs);
- 	  p->p_offset = m->sections[0]->filepos;
 diff -burN orig.binutils-2.14/bfd/elflink.h binutils-2.14/bfd/elflink.h
---- orig.binutils-2.14/bfd/elflink.h	2003-06-02 17:35:21.000000000 -0300
-+++ binutils-2.14/bfd/elflink.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/elflink.h	2003-06-02 22:35:21.000000000 +0200
++++ binutils-2.14/bfd/elflink.h	2017-03-08 00:37:47.494795039 +0100
 @@ -7238,9 +7238,18 @@
  			 elf_link_output_extsym that this symbol is
  			 used by a reloc.  */
@@ -507,8 +507,8 @@ diff -burN orig.binutils-2.14/bfd/elflink.h binutils-2.14/bfd/elflink.h
  
  		      /* Adjust the addend according to where the
 diff -burN orig.binutils-2.14/bfd/elfxx-mips.c binutils-2.14/bfd/elfxx-mips.c
---- orig.binutils-2.14/bfd/elfxx-mips.c	2003-06-02 17:35:22.000000000 -0300
-+++ binutils-2.14/bfd/elfxx-mips.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/elfxx-mips.c	2003-06-02 22:35:22.000000000 +0200
++++ binutils-2.14/bfd/elfxx-mips.c	2017-03-08 00:37:47.494795039 +0100
 @@ -4064,6 +4064,9 @@
      case E_MIPS_MACH_5500:
        return bfd_mach_mips5500;
@@ -634,8 +634,8 @@ diff -burN orig.binutils-2.14/bfd/elfxx-mips.c binutils-2.14/bfd/elfxx-mips.c
      }
    else if (!mips_mach_extends_p (bfd_get_mach (ibfd), bfd_get_mach (obfd)))
 diff -burN orig.binutils-2.14/bfd/libbfd.h binutils-2.14/bfd/libbfd.h
---- orig.binutils-2.14/bfd/libbfd.h	2003-04-01 11:50:27.000000000 -0400
-+++ binutils-2.14/bfd/libbfd.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/libbfd.h	2003-04-01 17:50:27.000000000 +0200
++++ binutils-2.14/bfd/libbfd.h	2017-03-08 00:37:47.494795039 +0100
 @@ -872,6 +872,7 @@
    "BFD_RELOC_MIPS_REL16",
    "BFD_RELOC_MIPS_RELGOT",
@@ -656,8 +656,8 @@ diff -burN orig.binutils-2.14/bfd/libbfd.h binutils-2.14/bfd/libbfd.h
    "BFD_RELOC_386_GOT32",
    "BFD_RELOC_386_PLT32",
 diff -burN orig.binutils-2.14/bfd/reloc.c binutils-2.14/bfd/reloc.c
---- orig.binutils-2.14/bfd/reloc.c	2003-04-23 18:09:02.000000000 -0300
-+++ binutils-2.14/bfd/reloc.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/bfd/reloc.c	2003-04-23 23:09:02.000000000 +0200
++++ binutils-2.14/bfd/reloc.c	2017-03-08 00:37:47.494795039 +0100
 @@ -2128,6 +2128,8 @@
    BFD_RELOC_MIPS_RELGOT
  ENUMX
@@ -696,8 +696,8 @@ diff -burN orig.binutils-2.14/bfd/reloc.c binutils-2.14/bfd/reloc.c
  ENUM
    BFD_RELOC_386_GOT32
 diff -burN orig.binutils-2.14/config.sub binutils-2.14/config.sub
---- orig.binutils-2.14/config.sub	2003-06-02 17:35:43.000000000 -0300
-+++ binutils-2.14/config.sub	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/config.sub	2003-06-02 22:35:43.000000000 +0200
++++ binutils-2.14/config.sub	2017-03-08 00:37:47.494795039 +0100
 @@ -250,6 +250,7 @@
  	| mipsisa64sb1 | mipsisa64sb1el \
  	| mipsisa64sr71k | mipsisa64sr71kel \
@@ -758,8 +758,8 @@ diff -burN orig.binutils-2.14/config.sub binutils-2.14/config.sub
  		;;
  	-qnx*)
 diff -burN orig.binutils-2.14/configure binutils-2.14/configure
---- orig.binutils-2.14/configure	2003-06-02 17:35:43.000000000 -0300
-+++ binutils-2.14/configure	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/configure	2003-06-02 22:35:43.000000000 +0200
++++ binutils-2.14/configure	2017-03-08 00:37:47.494795039 +0100
 @@ -1116,6 +1116,9 @@
    d30v-*-*)
      noconfigdirs="$noconfigdirs ${libgcj}"
@@ -771,8 +771,8 @@ diff -burN orig.binutils-2.14/configure binutils-2.14/configure
      noconfigdirs="$noconfigdirs ${libgcj}"
      ;;
 diff -burN orig.binutils-2.14/configure.in binutils-2.14/configure.in
---- orig.binutils-2.14/configure.in	2003-06-12 11:33:14.000000000 -0300
-+++ binutils-2.14/configure.in	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/configure.in	2003-06-12 16:33:14.000000000 +0200
++++ binutils-2.14/configure.in	2017-03-08 00:37:47.494795039 +0100
 @@ -456,6 +456,9 @@
    d30v-*-*)
      noconfigdirs="$noconfigdirs ${libgcj}"
@@ -784,9 +784,9 @@ diff -burN orig.binutils-2.14/configure.in binutils-2.14/configure.in
      noconfigdirs="$noconfigdirs ${libgcj}"
      ;;
 diff -burN orig.binutils-2.14/gas/config/tc-dvp.c binutils-2.14/gas/config/tc-dvp.c
---- orig.binutils-2.14/gas/config/tc-dvp.c	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/gas/config/tc-dvp.c	2007-04-29 04:00:33.000000000 -0300
-@@ -0,0 +1,3436 @@
+--- orig.binutils-2.14/gas/config/tc-dvp.c	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/gas/config/tc-dvp.c	2017-03-08 00:39:37.884800133 +0100
+@@ -0,0 +1,3441 @@
 +/* tc-dvp.c -- Assembler for the DVP
 +   Copyright (C) 1997, 1998 Free Software Foundation.
 +
@@ -2509,7 +2509,9 @@ diff -burN orig.binutils-2.14/gas/config/tc-dvp.c binutils-2.14/gas/config/tc-dv
 +     segT segment;
 +{
 +  /* Our initial estimate is always 0.  */
-+  return 0;
++  /* XXX return 0; */
++  /* XXX Reverse engineered from Sony's ee-dvp-as binary: */
++  return RELAX_DONE_P(fragP->fr_subtype) ? RELAX_GROWTH(fragP->fr_subtype) : 0;
 +} 
 +
 +/* Perform the relaxation.
@@ -2543,7 +2545,10 @@ diff -burN orig.binutils-2.14/gas/config/tc-dvp.c binutils-2.14/gas/config/tc-dv
 +      return 0;
 +    }
 +
-+  target = S_GET_VALUE (symbolP) + symbolP->sy_frag->fr_address;
++  /* XXX target = S_GET_VALUE (symbolP) + symbolP->sy_frag->fr_address; */
++  /* XXX The above segfault as symbolP->sy_frag is only a valid pointer when
++   * symbolP is not local. Sony's ee-dvp-as does not add fr_address. */
++  target = S_GET_VALUE (symbolP);
 +
 +  if (fragP->fr_subtype == RELAX_MPG)
 +    {
@@ -4224,8 +4229,8 @@ diff -burN orig.binutils-2.14/gas/config/tc-dvp.c binutils-2.14/gas/config/tc-dv
 +  do_s_func (end_p, VU_LABEL_PREFIX);
 +}
 diff -burN orig.binutils-2.14/gas/config/tc-dvp.h binutils-2.14/gas/config/tc-dvp.h
---- orig.binutils-2.14/gas/config/tc-dvp.h	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/gas/config/tc-dvp.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/gas/config/tc-dvp.h	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/gas/config/tc-dvp.h	2017-03-08 00:37:47.498128372 +0100
 @@ -0,0 +1,105 @@
 +/* tc-dvp.h -- Header file for tc-dvp.c.
 +   Copyright (C) 1997, 1998 Free Software Foundation, Inc.
@@ -4333,8 +4338,8 @@ diff -burN orig.binutils-2.14/gas/config/tc-dvp.h binutils-2.14/gas/config/tc-dv
 +  { ".vudata",	SHT_PROGBITS,	SHF_ALLOC + SHF_WRITE		}, \
 +  { ".vutext",	SHT_PROGBITS,	SHF_ALLOC + SHF_EXECINSTR	},
 diff -burN orig.binutils-2.14/gas/config/tc-mips.c binutils-2.14/gas/config/tc-mips.c
---- orig.binutils-2.14/gas/config/tc-mips.c	2003-06-02 17:35:25.000000000 -0300
-+++ binutils-2.14/gas/config/tc-mips.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/gas/config/tc-mips.c	2003-06-02 22:35:25.000000000 +0200
++++ binutils-2.14/gas/config/tc-mips.c	2017-03-08 00:37:47.498128372 +0100
 @@ -177,6 +177,10 @@
       is passed but can changed if the assembler code uses .set mipsN.  */
    int gp32;
@@ -5467,8 +5472,8 @@ diff -burN orig.binutils-2.14/gas/config/tc-mips.c binutils-2.14/gas/config/tc-m
  
    fprintf (stream, _("\
 diff -burN orig.binutils-2.14/gas/configure binutils-2.14/gas/configure
---- orig.binutils-2.14/gas/configure	2003-06-02 17:35:23.000000000 -0300
-+++ binutils-2.14/gas/configure	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/gas/configure	2003-06-02 22:35:23.000000000 +0200
++++ binutils-2.14/gas/configure	2017-03-08 00:37:47.501461706 +0100
 @@ -2338,6 +2338,7 @@
        m5200)		cpu_type=m68k ;;
        m8*)		cpu_type=m88k ;;
@@ -5503,8 +5508,8 @@ diff -burN orig.binutils-2.14/gas/configure binutils-2.14/gas/configure
        mmix-*-*)				fmt=elf ;;
        mn10200-*-*)			fmt=elf ;;
 diff -burN orig.binutils-2.14/gas/configure.in binutils-2.14/gas/configure.in
---- orig.binutils-2.14/gas/configure.in	2003-06-02 17:35:23.000000000 -0300
-+++ binutils-2.14/gas/configure.in	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/gas/configure.in	2003-06-02 22:35:23.000000000 +0200
++++ binutils-2.14/gas/configure.in	2017-03-08 00:37:47.501461706 +0100
 @@ -132,6 +132,7 @@
        m5200)		cpu_type=m68k ;;
        m8*)		cpu_type=m88k ;;
@@ -5531,8 +5536,8 @@ diff -burN orig.binutils-2.14/gas/configure.in binutils-2.14/gas/configure.in
        mmix-*-*)				fmt=elf ;;
        mn10200-*-*)			fmt=elf ;;
 diff -burN orig.binutils-2.14/include/dis-asm.h binutils-2.14/include/dis-asm.h
---- orig.binutils-2.14/include/dis-asm.h	2003-04-01 11:50:30.000000000 -0400
-+++ binutils-2.14/include/dis-asm.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/include/dis-asm.h	2003-04-01 17:50:30.000000000 +0200
++++ binutils-2.14/include/dis-asm.h	2017-03-08 00:37:47.501461706 +0100
 @@ -242,6 +242,8 @@
  extern int print_insn_sh64x_media	PARAMS ((bfd_vma, disassemble_info *));
  extern int print_insn_frv		PARAMS ((bfd_vma, disassemble_info *));
@@ -5543,8 +5548,8 @@ diff -burN orig.binutils-2.14/include/dis-asm.h binutils-2.14/include/dis-asm.h
  extern disassembler_ftype arc_get_disassembler PARAMS ((void *));
  extern disassembler_ftype cris_get_disassembler PARAMS ((bfd *));
 diff -burN orig.binutils-2.14/include/elf/common.h binutils-2.14/include/elf/common.h
---- orig.binutils-2.14/include/elf/common.h	2003-04-23 18:09:04.000000000 -0300
-+++ binutils-2.14/include/elf/common.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/include/elf/common.h	2003-04-23 23:09:04.000000000 +0200
++++ binutils-2.14/include/elf/common.h	2017-03-08 00:37:47.501461706 +0100
 @@ -92,6 +92,7 @@
  #define ET_LOOS		0xFE00	/* Operating system-specific */
  #define ET_HIOS		0xFEFF	/* Operating system-specific */
@@ -5562,8 +5567,8 @@ diff -burN orig.binutils-2.14/include/elf/common.h binutils-2.14/include/elf/com
  #define PT_GNU_EH_FRAME	(PT_LOOS + 0x474e550)
  
 diff -burN orig.binutils-2.14/include/elf/mips.h binutils-2.14/include/elf/mips.h
---- orig.binutils-2.14/include/elf/mips.h	2003-01-27 20:01:08.000000000 -0400
-+++ binutils-2.14/include/elf/mips.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/include/elf/mips.h	2003-01-28 01:01:08.000000000 +0100
++++ binutils-2.14/include/elf/mips.h	2017-03-08 00:37:47.501461706 +0100
 @@ -76,6 +76,13 @@
    /* These relocs are used for the mips16.  */
    RELOC_NUMBER (R_MIPS16_26, 100)
@@ -5665,8 +5670,8 @@ diff -burN orig.binutils-2.14/include/elf/mips.h binutils-2.14/include/elf/mips.
  #define OEX_FPU_MIN	0x1f	/* FPEs which must be enabled.  */
  #define OEX_FPU_MAX	0x1f00	/* FPEs which may be enabled.  */
 diff -burN orig.binutils-2.14/include/opcode/dvp.h binutils-2.14/include/opcode/dvp.h
---- orig.binutils-2.14/include/opcode/dvp.h	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/include/opcode/dvp.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/include/opcode/dvp.h	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/include/opcode/dvp.h	2017-03-08 00:37:47.501461706 +0100
 @@ -0,0 +1,454 @@
 +/* Opcode table for the DVP.
 +   Copyright 1998 Free Software Foundation, Inc.
@@ -6123,8 +6128,8 @@ diff -burN orig.binutils-2.14/include/opcode/dvp.h binutils-2.14/include/opcode/
 +void dvp_opcode_init_parse PARAMS ((void));
 +void dvp_opcode_init_print PARAMS ((void));
 diff -burN orig.binutils-2.14/include/opcode/mips.h binutils-2.14/include/opcode/mips.h
---- orig.binutils-2.14/include/opcode/mips.h	2003-04-08 21:12:24.000000000 -0300
-+++ binutils-2.14/include/opcode/mips.h	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/include/opcode/mips.h	2003-04-09 02:12:24.000000000 +0200
++++ binutils-2.14/include/opcode/mips.h	2017-03-08 00:37:47.501461706 +0100
 @@ -164,6 +164,24 @@
  #define	OP_OP_SDC2		0x3e
  #define	OP_OP_SDC3		0x3f	/* a.k.a. sd */
@@ -6243,9 +6248,87 @@ diff -burN orig.binutils-2.14/include/opcode/mips.h binutils-2.14/include/opcode
       || 0)	/* Please keep this term for easier source merging.  */
  
  /* This is a list of macro expanded instructions.
+diff -burN orig.binutils-2.14/ld/Makefile.am binutils-2.14/ld/Makefile.am
+--- orig.binutils-2.14/ld/Makefile.am	2003-04-24 14:36:07.000000000 +0200
++++ binutils-2.14/ld/Makefile.am	2017-03-08 00:37:47.501461706 +0100
+@@ -154,6 +154,7 @@
+ 	eelf32_i860.o \
+ 	eelf32_sparc.o \
+ 	eelf32b4300.o \
++	eelf32l5900.o \
+ 	eelf32bmip.o \
+ 	eelf32bmipn32.o \
+ 	eelf32btsmip.o \
+@@ -249,6 +250,7 @@
+ 	emipsbsd.o \
+ 	emipsidt.o \
+ 	emipsidtl.o \
++	emipsirx.o \
+ 	emipslit.o \
+ 	emipslnews.o \
+ 	emipspe.o \
+@@ -662,6 +664,9 @@
+   $(srcdir)/emulparams/elf32b4300.sh $(srcdir)/emulparams/elf32bmip.sh \
+   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+ 	${GENSCRIPTS} elf32l4300 "$(tdir_elf32l4300)"
++eelf32l5900.c: $(srcdir)/emulparams/elf32l5900.sh
++  $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
++	${GENSCRIPTS} elf32l5900 "$(tdir_elf32l5900)"
+ eelf32lmip.c: $(srcdir)/emulparams/elf32lmip.sh \
+   $(srcdir)/emulparams/elf32bmip.sh \
+   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+@@ -1002,6 +1007,9 @@
+ emipsidtl.c: $(srcdir)/emulparams/mipsidtl.sh \
+   $(srcdir)/emultempl/mipsecoff.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
+ 	${GENSCRIPTS} mipsidtl "$(tdir_mipsidtl)"
++emipsirx.c:  $(srcdir)/emulparams/mipsirx.sh \
++  $(srcdir)/emultempl/irx.em $(srcdir)/scripttempl/irx.sc ${GEN_DEPENDS}
++	${GENSCRIPTS} mipsirx "$(tdir_mipsirx)"
+ emipslit.c:  $(srcdir)/emulparams/mipslit.sh \
+   $(srcdir)/emultempl/generic.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
+ 	${GENSCRIPTS} mipslit "$(tdir_mipslit)"
+diff -burN orig.binutils-2.14/ld/Makefile.in binutils-2.14/ld/Makefile.in
+--- orig.binutils-2.14/ld/Makefile.in	2003-04-24 14:36:07.000000000 +0200
++++ binutils-2.14/ld/Makefile.in	2017-03-08 00:37:47.501461706 +0100
+@@ -283,6 +283,7 @@
+ 	eelf32iq2000.o \
+ 	eelf32iq10.o \
+ 	eelf32l4300.o \
++	eelf32l5900.o \
+ 	eelf32lmip.o \
+ 	eelf32lppc.o \
+ 	eelf32lppcnto.o \
+@@ -363,6 +364,7 @@
+ 	emipsbsd.o \
+ 	emipsidt.o \
+ 	emipsidtl.o \
++	emipsirx.o \
+ 	emipslit.o \
+ 	emipslnews.o \
+ 	emipspe.o \
+@@ -1388,6 +1390,9 @@
+   $(srcdir)/emulparams/elf32b4300.sh $(srcdir)/emulparams/elf32bmip.sh \
+   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+ 	${GENSCRIPTS} elf32l4300 "$(tdir_elf32l4300)"
++eelf32l5900.c: $(srcdir)/emulparams/elf32l5900.sh \
++  $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
++	${GENSCRIPTS} elf32l5900 "$(tdir_elf32l5900)"
+ eelf32lmip.c: $(srcdir)/emulparams/elf32lmip.sh \
+   $(srcdir)/emulparams/elf32bmip.sh \
+   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+@@ -1728,6 +1733,9 @@
+ emipsidtl.c: $(srcdir)/emulparams/mipsidtl.sh \
+   $(srcdir)/emultempl/mipsecoff.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
+ 	${GENSCRIPTS} mipsidtl "$(tdir_mipsidtl)"
++emipsirx.c:  $(srcdir)/emulparams/mipsirx.sh \
++  $(srcdir)/emultempl/irx.em $(srcdir)/scripttempl/irx.sc ${GEN_DEPENDS}
++	${GENSCRIPTS} mipsirx "$(tdir_mipsirx)"
+ emipslit.c:  $(srcdir)/emulparams/mipslit.sh \
+   $(srcdir)/emultempl/generic.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
+ 	${GENSCRIPTS} mipslit "$(tdir_mipslit)"
 diff -burN orig.binutils-2.14/ld/configure.tgt binutils-2.14/ld/configure.tgt
---- orig.binutils-2.14/ld/configure.tgt	2003-06-12 11:25:52.000000000 -0300
-+++ binutils-2.14/ld/configure.tgt	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/ld/configure.tgt	2003-06-12 16:25:52.000000000 +0200
++++ binutils-2.14/ld/configure.tgt	2017-03-08 00:37:47.501461706 +0100
 @@ -404,8 +404,15 @@
  mips*vr4100-*-elf*)	targ_emul=elf32b4300 ;;
  mips*vr5000el-*-elf*)	targ_emul=elf32l4300 ;;
@@ -6263,8 +6346,8 @@ diff -burN orig.binutils-2.14/ld/configure.tgt binutils-2.14/ld/configure.tgt
  mips*-*-rtems*)		targ_emul=elf32ebmip ;;
  mips*el-*-vxworks*)	targ_emul=elf32elmip ;;
 diff -burN orig.binutils-2.14/ld/emulparams/elf32l5900.sh binutils-2.14/ld/emulparams/elf32l5900.sh
---- orig.binutils-2.14/ld/emulparams/elf32l5900.sh	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/ld/emulparams/elf32l5900.sh	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/ld/emulparams/elf32l5900.sh	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/ld/emulparams/elf32l5900.sh	2017-03-08 00:37:47.501461706 +0100
 @@ -0,0 +1,29 @@
 +SCRIPT_NAME=elf
 +OUTPUT_FORMAT="elf32-littlemips"
@@ -6296,8 +6379,8 @@ diff -burN orig.binutils-2.14/ld/emulparams/elf32l5900.sh binutils-2.14/ld/emulp
 +DYNAMIC_LINK=FALSE
 +EMBEDDED=yes
 diff -burN orig.binutils-2.14/ld/emulparams/mipsirx.sh binutils-2.14/ld/emulparams/mipsirx.sh
---- orig.binutils-2.14/ld/emulparams/mipsirx.sh	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/ld/emulparams/mipsirx.sh	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/ld/emulparams/mipsirx.sh	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/ld/emulparams/mipsirx.sh	2017-03-08 00:37:47.501461706 +0100
 @@ -0,0 +1,8 @@
 +SCRIPT_NAME=irx
 +OUTPUT_FORMAT="elf32-littlemips"
@@ -6308,8 +6391,8 @@ diff -burN orig.binutils-2.14/ld/emulparams/mipsirx.sh binutils-2.14/ld/emulpara
 +TEMPLATE_NAME=irx
 +
 diff -burN orig.binutils-2.14/ld/emultempl/irx.em binutils-2.14/ld/emultempl/irx.em
---- orig.binutils-2.14/ld/emultempl/irx.em	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/ld/emultempl/irx.em	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/ld/emultempl/irx.em	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/ld/emultempl/irx.em	2017-03-08 00:37:47.501461706 +0100
 @@ -0,0 +1,560 @@
 +# This shell script emits a C file. -*- C -*-
 +# It does some substitutions.
@@ -6871,87 +6954,9 @@ diff -burN orig.binutils-2.14/ld/emultempl/irx.em binutils-2.14/ld/emultempl/irx
 +  NULL
 +};
 +EOF
-diff -burN orig.binutils-2.14/ld/Makefile.am binutils-2.14/ld/Makefile.am
---- orig.binutils-2.14/ld/Makefile.am	2003-04-24 09:36:07.000000000 -0300
-+++ binutils-2.14/ld/Makefile.am	2007-04-29 04:00:33.000000000 -0300
-@@ -154,6 +154,7 @@
- 	eelf32_i860.o \
- 	eelf32_sparc.o \
- 	eelf32b4300.o \
-+	eelf32l5900.o \
- 	eelf32bmip.o \
- 	eelf32bmipn32.o \
- 	eelf32btsmip.o \
-@@ -249,6 +250,7 @@
- 	emipsbsd.o \
- 	emipsidt.o \
- 	emipsidtl.o \
-+	emipsirx.o \
- 	emipslit.o \
- 	emipslnews.o \
- 	emipspe.o \
-@@ -662,6 +664,9 @@
-   $(srcdir)/emulparams/elf32b4300.sh $(srcdir)/emulparams/elf32bmip.sh \
-   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
- 	${GENSCRIPTS} elf32l4300 "$(tdir_elf32l4300)"
-+eelf32l5900.c: $(srcdir)/emulparams/elf32l5900.sh
-+  $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
-+	${GENSCRIPTS} elf32l5900 "$(tdir_elf32l5900)"
- eelf32lmip.c: $(srcdir)/emulparams/elf32lmip.sh \
-   $(srcdir)/emulparams/elf32bmip.sh \
-   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
-@@ -1002,6 +1007,9 @@
- emipsidtl.c: $(srcdir)/emulparams/mipsidtl.sh \
-   $(srcdir)/emultempl/mipsecoff.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
- 	${GENSCRIPTS} mipsidtl "$(tdir_mipsidtl)"
-+emipsirx.c:  $(srcdir)/emulparams/mipsirx.sh \
-+  $(srcdir)/emultempl/irx.em $(srcdir)/scripttempl/irx.sc ${GEN_DEPENDS}
-+	${GENSCRIPTS} mipsirx "$(tdir_mipsirx)"
- emipslit.c:  $(srcdir)/emulparams/mipslit.sh \
-   $(srcdir)/emultempl/generic.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
- 	${GENSCRIPTS} mipslit "$(tdir_mipslit)"
-diff -burN orig.binutils-2.14/ld/Makefile.in binutils-2.14/ld/Makefile.in
---- orig.binutils-2.14/ld/Makefile.in	2003-04-24 09:36:07.000000000 -0300
-+++ binutils-2.14/ld/Makefile.in	2007-04-29 04:00:33.000000000 -0300
-@@ -283,6 +283,7 @@
- 	eelf32iq2000.o \
- 	eelf32iq10.o \
- 	eelf32l4300.o \
-+	eelf32l5900.o \
- 	eelf32lmip.o \
- 	eelf32lppc.o \
- 	eelf32lppcnto.o \
-@@ -363,6 +364,7 @@
- 	emipsbsd.o \
- 	emipsidt.o \
- 	emipsidtl.o \
-+	emipsirx.o \
- 	emipslit.o \
- 	emipslnews.o \
- 	emipspe.o \
-@@ -1388,6 +1390,9 @@
-   $(srcdir)/emulparams/elf32b4300.sh $(srcdir)/emulparams/elf32bmip.sh \
-   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
- 	${GENSCRIPTS} elf32l4300 "$(tdir_elf32l4300)"
-+eelf32l5900.c: $(srcdir)/emulparams/elf32l5900.sh \
-+  $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
-+	${GENSCRIPTS} elf32l5900 "$(tdir_elf32l5900)"
- eelf32lmip.c: $(srcdir)/emulparams/elf32lmip.sh \
-   $(srcdir)/emulparams/elf32bmip.sh \
-   $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
-@@ -1728,6 +1733,9 @@
- emipsidtl.c: $(srcdir)/emulparams/mipsidtl.sh \
-   $(srcdir)/emultempl/mipsecoff.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
- 	${GENSCRIPTS} mipsidtl "$(tdir_mipsidtl)"
-+emipsirx.c:  $(srcdir)/emulparams/mipsirx.sh \
-+  $(srcdir)/emultempl/irx.em $(srcdir)/scripttempl/irx.sc ${GEN_DEPENDS}
-+	${GENSCRIPTS} mipsirx "$(tdir_mipsirx)"
- emipslit.c:  $(srcdir)/emulparams/mipslit.sh \
-   $(srcdir)/emultempl/generic.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
- 	${GENSCRIPTS} mipslit "$(tdir_mipslit)"
 diff -burN orig.binutils-2.14/ld/scripttempl/irx.sc binutils-2.14/ld/scripttempl/irx.sc
---- orig.binutils-2.14/ld/scripttempl/irx.sc	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/ld/scripttempl/irx.sc	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/ld/scripttempl/irx.sc	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/ld/scripttempl/irx.sc	2017-03-08 00:37:47.504795039 +0100
 @@ -0,0 +1,121 @@
 +# Link scripts for PlayStation 2 IRXs.
 +
@@ -7075,8 +7080,8 @@ diff -burN orig.binutils-2.14/ld/scripttempl/irx.sc binutils-2.14/ld/scripttempl
 +
 +EOF
 diff -burN orig.binutils-2.14/opcodes/configure binutils-2.14/opcodes/configure
---- orig.binutils-2.14/opcodes/configure	2003-06-02 17:35:17.000000000 -0300
-+++ binutils-2.14/opcodes/configure	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/configure	2003-06-02 22:35:17.000000000 +0200
++++ binutils-2.14/opcodes/configure	2017-03-08 00:37:47.504795039 +0100
 @@ -4671,6 +4671,7 @@
          bfd_tic4x_arch)         ta="$ta tic4x-dis.lo" ;;
  	bfd_tic54x_arch)	ta="$ta tic54x-dis.lo tic54x-opc.lo" ;;
@@ -7086,8 +7091,8 @@ diff -burN orig.binutils-2.14/opcodes/configure binutils-2.14/opcodes/configure
  	bfd_v850e_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
  	bfd_v850ea_arch)	ta="$ta v850-opc.lo v850-dis.lo" ;;
 diff -burN orig.binutils-2.14/opcodes/configure.in binutils-2.14/opcodes/configure.in
---- orig.binutils-2.14/opcodes/configure.in	2003-06-02 17:35:17.000000000 -0300
-+++ binutils-2.14/opcodes/configure.in	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/configure.in	2003-06-02 22:35:17.000000000 +0200
++++ binutils-2.14/opcodes/configure.in	2017-03-08 00:37:47.504795039 +0100
 @@ -234,6 +234,7 @@
          bfd_tic4x_arch)         ta="$ta tic4x-dis.lo" ;;
  	bfd_tic54x_arch)	ta="$ta tic54x-dis.lo tic54x-opc.lo" ;;
@@ -7097,8 +7102,8 @@ diff -burN orig.binutils-2.14/opcodes/configure.in binutils-2.14/opcodes/configu
  	bfd_v850e_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
  	bfd_v850ea_arch)	ta="$ta v850-opc.lo v850-dis.lo" ;;
 diff -burN orig.binutils-2.14/opcodes/disassemble.c binutils-2.14/opcodes/disassemble.c
---- orig.binutils-2.14/opcodes/disassemble.c	2003-04-01 11:50:30.000000000 -0400
-+++ binutils-2.14/opcodes/disassemble.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/disassemble.c	2003-04-01 17:50:30.000000000 +0200
++++ binutils-2.14/opcodes/disassemble.c	2017-03-08 00:37:47.504795039 +0100
 @@ -75,7 +75,6 @@
  #define INCLUDE_SHMEDIA
  #endif
@@ -7126,8 +7131,8 @@ diff -burN orig.binutils-2.14/opcodes/disassemble.c binutils-2.14/opcodes/disass
  #endif
  #ifdef ARCH_mmix
 diff -burN orig.binutils-2.14/opcodes/dvp-dis.c binutils-2.14/opcodes/dvp-dis.c
---- orig.binutils-2.14/opcodes/dvp-dis.c	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/opcodes/dvp-dis.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/dvp-dis.c	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/opcodes/dvp-dis.c	2017-03-08 00:37:47.504795039 +0100
 @@ -0,0 +1,439 @@
 +/* Instruction printing code for the DVP
 +   Copyright (C) 1998 Free Software Foundation, Inc. 
@@ -7569,8 +7574,8 @@ diff -burN orig.binutils-2.14/opcodes/dvp-dis.c binutils-2.14/opcodes/dvp-dis.c
 +  return 0;
 +}
 diff -burN orig.binutils-2.14/opcodes/dvp-opc.c binutils-2.14/opcodes/dvp-opc.c
---- orig.binutils-2.14/opcodes/dvp-opc.c	1969-12-31 20:00:00.000000000 -0400
-+++ binutils-2.14/opcodes/dvp-opc.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/dvp-opc.c	1970-01-01 01:00:00.000000000 +0100
++++ binutils-2.14/opcodes/dvp-opc.c	2017-03-08 00:37:47.504795039 +0100
 @@ -0,0 +1,3458 @@
 +/* Opcode table for the DVP
 +   Copyright (c) 1998 Free Software Foundation, Inc.
@@ -11031,8 +11036,8 @@ diff -burN orig.binutils-2.14/opcodes/dvp-opc.c binutils-2.14/opcodes/dvp-opc.c
 +  return NULL;
 +}
 diff -burN orig.binutils-2.14/opcodes/mips-dis.c binutils-2.14/opcodes/mips-dis.c
---- orig.binutils-2.14/opcodes/mips-dis.c	2003-04-08 04:14:47.000000000 -0300
-+++ binutils-2.14/opcodes/mips-dis.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/mips-dis.c	2003-04-08 09:14:47.000000000 +0200
++++ binutils-2.14/opcodes/mips-dis.c	2017-03-08 00:37:47.504795039 +0100
 @@ -345,6 +345,8 @@
      mips_cp0_names_numeric, NULL, 0, mips_hwr_names_numeric },
    { "vr5500",	1, bfd_mach_mips5500, CPU_VR5500, ISA_MIPS4,
@@ -11232,8 +11237,8 @@ diff -burN orig.binutils-2.14/opcodes/mips-dis.c binutils-2.14/opcodes/mips-dis.
    parse_mips_dis_options (info->disassembler_options);
  
 diff -burN orig.binutils-2.14/opcodes/mips-opc.c binutils-2.14/opcodes/mips-opc.c
---- orig.binutils-2.14/opcodes/mips-opc.c	2002-12-31 21:06:13.000000000 -0400
-+++ binutils-2.14/opcodes/mips-opc.c	2007-04-29 04:00:33.000000000 -0300
+--- orig.binutils-2.14/opcodes/mips-opc.c	2003-01-01 02:06:13.000000000 +0100
++++ binutils-2.14/opcodes/mips-opc.c	2017-03-08 00:37:47.508128373 +0100
 @@ -101,6 +101,7 @@
  #define L1	INSN_4010
  #define V1	(INSN_4100 | INSN_4111 | INSN_4120)


### PR DESCRIPTION
Some functions in Sony's ee-dvp-as binary are slightly different
from the ps2toolchain dvp-as. This patch changes md_estimate_size_before_relax
and dvp_relax_frag to behave like those in Sony's binary.