### PR TITLE
Update binutils and gcc scripts

### DIFF
--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -3,7 +3,7 @@
 
 BINUTILS_VERSION=2.14
 ## Download the source code.
-SOURCE=http://ftpmirror.gnu.org/binutils/binutils-$BINUTILS_VERSION.tar.bz2
+SOURCE=https://ftpmirror.gnu.org/binutils/binutils-$BINUTILS_VERSION.tar.bz2
 wget --continue $SOURCE || { exit 1; }
 
 ## Unpack the source code.

--- a/scripts/002-gcc-3.2.3-stage1.sh
+++ b/scripts/002-gcc-3.2.3-stage1.sh
@@ -4,7 +4,7 @@
 
 GCC_VERSION=3.2.3
 ## Download the source code.
-SOURCE=http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2
+SOURCE=https://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2
 wget --continue $SOURCE || { exit 1; }
 
 ## Unpack the source code.

--- a/scripts/004-gcc-3.2.3-stage2.sh
+++ b/scripts/004-gcc-3.2.3-stage2.sh
@@ -4,7 +4,7 @@
 
 GCC_VERSION=3.2.3
 ## Download the source code.
-SOURCE=http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2
+SOURCE=https://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2
 wget --continue $SOURCE || { exit 1; }
 
 ## Unpack the source code.


### PR DESCRIPTION
ftpmirror.gnu.org is no longer accessible over http.