### PR TITLE
Set default parameters for compiling and linking EE binaries

### DIFF
--- a/patches/binutils-2.14-PS2.patch
+++ b/patches/binutils-2.14-PS2.patch
@@ -6348,14 +6348,13 @@ diff -burN orig.binutils-2.14/ld/configure.tgt binutils-2.14/ld/configure.tgt
 diff -burN orig.binutils-2.14/ld/emulparams/elf32l5900.sh binutils-2.14/ld/emulparams/elf32l5900.sh
 --- orig.binutils-2.14/ld/emulparams/elf32l5900.sh	1970-01-01 01:00:00.000000000 +0100
 +++ binutils-2.14/ld/emulparams/elf32l5900.sh	2017-03-08 00:37:47.501461706 +0100
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,31 @@
 +SCRIPT_NAME=elf
 +OUTPUT_FORMAT="elf32-littlemips"
 +BIG_OUTPUT_FORMAT="elf32-bigmips"
 +LITTLE_OUTPUT_FORMAT="elf32-littlemips"
 +TEXT_START_ADDR=0x100000
 +MAXPAGESIZE=128
-+INITIAL_READONLY_SECTIONS='.reginfo : { *(.reginfo) }'
 +OTHER_TEXT_SECTIONS='*(.mips16.fn.*) *(.mips16.call.*)'
 +OTHER_GOT_SYMBOLS='
 +  _gp = ALIGN(16) + 0x7ff0;
@@ -6371,6 +6370,9 @@ diff -burN orig.binutils-2.14/ld/emulparams/elf32l5900.sh binutils-2.14/ld/emulp
 +OTHER_SECTIONS='
 +  .gptab.sdata : { *(.gptab.data) *(.gptab.sdata) }
 +  .gptab.sbss : { *(.gptab.bss) *(.gptab.sbss) }
++  PROVIDE(_heap_size = -1);
++  PROVIDE(_stack = -1);
++  PROVIDE(_stack_size = 128 * 1024);
 +'
 +ARCH="mips:5900"
 +MACHINE=

--- a/patches/gcc-3.2.3-PS2.patch
+++ b/patches/gcc-3.2.3-PS2.patch
@@ -4050,7 +4050,7 @@ diff -rupNb gcc-3.2.3/gcc/config/mips/mips-protos.h gcc-3.2.3-new/gcc/config/mip
 diff -rupNb gcc-3.2.3/gcc/config/mips/r5900.h gcc-3.2.3-new/gcc/config/mips/r5900.h
 --- gcc-3.2.3/gcc/config/mips/r5900.h	1970-01-01 07:30:00.000000000 +0730
 +++ gcc-3.2.3-new/gcc/config/mips/r5900.h	2016-07-02 09:25:57.521368595 +0800
-@@ -0,0 +1,285 @@
+@@ -0,0 +1,287 @@
 +/*
 + * Target machine definitions for the Toshiba r5900.
 + *
@@ -4083,6 +4083,8 @@ diff -rupNb gcc-3.2.3/gcc/config/mips/r5900.h gcc-3.2.3-new/gcc/config/mips/r590
 +
 +#undef MACHINE_TYPE
 +#define MACHINE_TYPE "(MIPSel R5900 ELF)"
++
++#define LIB_SPEC "-L/usr/local/ps2dev/ps2sdk/ee/lib /usr/local/ps2dev/ps2sdk/ee/lib/libc.a -lkernel -lc -lg -lm"
 +
 +/*
 + I started doing some macro fixes, but as we plan to use 3.4 soon I'm not risking changing stuff I'm not


### PR DESCRIPTION
This change allows ee binaries to be compiled without adding extra parameters.

So instead of:
`ee-gcc -mno-crt0 -T/usr/local/ps2dev/ps2sdk/ee/startup/linkfile -o hello.elf /usr/local/ps2dev/ps2sdk/ee/startup/crt0.o helloworld.c -L/usr/local/ps2dev/ps2sdk/ee/lib -lc -lkernel`

We can now write:
`ee-gcc -o hello.elf helloworld.c`

The linking is not exactly the same as the linkfile from ps2sdk, but it does produce working binaries as far as I can tell. But still I would advise to keep using the ps2sdk linkfile:
`ee-gcc -T/usr/local/ps2dev/ps2sdk/ee/startup/linkfile -o hello.elf helloworld.c`