### PR TITLE
Fix for when $PS2SDK is not at default location

### DIFF
--- a/patches/gcc-3.2.3-PS2.patch
+++ b/patches/gcc-3.2.3-PS2.patch
@@ -4084,7 +4084,7 @@ diff -rupNb gcc-3.2.3/gcc/config/mips/r5900.h gcc-3.2.3-new/gcc/config/mips/r590
 +#undef MACHINE_TYPE
 +#define MACHINE_TYPE "(MIPSel R5900 ELF)"
 +
-+#define LIB_SPEC "-L/usr/local/ps2dev/ps2sdk/ee/lib /usr/local/ps2dev/ps2sdk/ee/lib/libc.a -lkernel -lc -lg -lm"
++#define LIB_SPEC "-lps2sdkc -lkernel -lc -lg -lm"
 +
 +/*
 + I started doing some macro fixes, but as we plan to use 3.4 soon I'm not risking changing stuff I'm not

--- a/scripts/005-ps2sdk.sh
+++ b/scripts/005-ps2sdk.sh
@@ -29,5 +29,10 @@ fi
 make clean && make -j $PROC_NR && make install && make clean || { exit 1; }
 
 ## Replace newlib's crt0 with the one in ps2sdk.
-ln -sf "$PS2SDK/ee/startup/crt0.o" "$PS2DEV/ee/lib/gcc-lib/ee/3.2.3/crt0.o" || { exit 1; }
-ln -sf "$PS2SDK/ee/startup/crt0.o" "$PS2DEV/ee/ee/lib/crt0.o" || { exit 1; }
+ln -sf "$PS2SDK/ee/startup/crt0.o"  "$PS2DEV/ee/lib/gcc-lib/ee/3.2.3/crt0.o" || { exit 1; }
+ln -sf "$PS2SDK/ee/startup/crt0.o"  "$PS2DEV/ee/ee/lib/crt0.o" || { exit 1; }
+
+## gcc needs to include both libc and libkernel from ps2sdk to be able to build executables.
+## NOTE: There are TWO libc libraries, gcc needs to include them both.
+ln -sf "$PS2SDK/ee/lib/libc.a"      "$PS2DEV/ee/ee/lib/libps2sdkc.a" || { exit 1; }
+ln -sf "$PS2SDK/ee/lib/libkernel.a" "$PS2DEV/ee/ee/lib/libkernel.a" || { exit 1; }


### PR DESCRIPTION
Fixed path "-L/usr/local/ps2dev/ps2sdk/ee/lib /usr/local/ps2dev/ps2sdk/ee/lib/libc.a" couses problems when not installed to that location.

note: Travis-CI (automated builds) has a problem with this.