### PR TITLE
re-add -G0 compile flag

### DIFF
--- a/scripts/003-newlib-1.10.0.sh
+++ b/scripts/003-newlib-1.10.0.sh
@@ -35,4 +35,4 @@ mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 ../configure --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
 
 ## Compile and install.
-make clean && make -j $PROC_NR && make install && make clean || { exit 1; }
+make clean && CPPFLAGS="-G0" make -j $PROC_NR && make install && make clean || { exit 1; }


### PR DESCRIPTION
Fixes linking errors such as:
```
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(writer.o)(.text+0x1c): In function `_write_r':
../../../../../newlib/libc/reent/writer.c:57: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(writer.o)(.text+0x48):../../../../../newlib/libc/reent/writer.c:60: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(closer.o)(.text+0x4): In function `_close_r':
../../../../../newlib/libc/reent/closer.c:52: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(closer.o)(.text+0x38):../../../../../newlib/libc/reent/closer.c:55: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(fstatr.o)(.text+0x18): In function `_fstat_r':
../../../../../newlib/libc/reent/fstatr.c:61: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(fstatr.o)(.text+0x40):../../../../../newlib/libc/reent/fstatr.c:64: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(lseekr.o)(.text+0x1c): In function `_lseek_r':
../../../../../newlib/libc/reent/lseekr.c:57: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(lseekr.o)(.text+0x48):../../../../../newlib/libc/reent/lseekr.c:60: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(readr.o)(.text+0x1c): In function `_read_r':
../../../../../newlib/libc/reent/readr.c:57: relocation truncated to fit: R_MIPS_GPREL16 errno
/ps2dev/ee/lib/gcc-lib/ee/3.2.3/../../../../ee/lib/libg.a(readr.o)(.text+0x48):../../../../../newlib/libc/reent/readr.c:60: relocation truncated to fit: R_MIPS_GPREL16 errno
```