### PR TITLE
Add native 64-bit windows host build support

### DIFF
--- a/patches/binutils-2.14-add-64bit-mingw-w64-toolchain-support.patch
+++ b/patches/binutils-2.14-add-64bit-mingw-w64-toolchain-support.patch
@@ -1,0 +1,18 @@
+diff --git a/include/splay-tree.h b/include/splay-tree.h
+index 86707fc..75a4d0b 100644
+--- a/include/splay-tree.h
++++ b/include/splay-tree.h
+@@ -44,8 +44,13 @@ extern "C" {
+    these types, if necessary.  These types should be sufficiently wide
+    that any pointer or scalar can be cast to these types, and then
+    cast back, without loss of precision.  */
++#ifdef __MINGW64__
++typedef unsigned long long int splay_tree_key;
++typedef unsigned long long int splay_tree_value;
++#else
+ typedef unsigned long int splay_tree_key;
+ typedef unsigned long int splay_tree_value;
++#endif
+ 
+ /* Forward declaration for a node in the tree.  */
+ typedef struct splay_tree_node_s *splay_tree_node;

--- a/patches/gcc-3.2.3-add-64bit-mingw-w64-toolchain-support.patch
+++ b/patches/gcc-3.2.3-add-64bit-mingw-w64-toolchain-support.patch
@@ -1,0 +1,121 @@
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 9cb1c9f..1813ef8 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -1535,7 +1535,7 @@ i[34567]86-*-mingw32*)
+ 	fi
+ 	exeext=.exe
+ 	;;
+-i[34567]86-*-mingw32*)
++i[34567]86-*-mingw32* | x86_64-*-mingw32*)
+ 	tm_file=i386/mingw32.h
+ 	float_format=i386
+ 	xm_defines=POSIX
+diff --git a/gcc/config/i386/xm-mingw32.h b/gcc/config/i386/xm-mingw32.h
+index b566fd9..9c3abb4 100644
+--- a/gcc/config/i386/xm-mingw32.h
++++ b/gcc/config/i386/xm-mingw32.h
+@@ -32,6 +32,10 @@ Boston, MA 02111-1307, USA.  */
+ #undef PATH_SEPARATOR
+ #define PATH_SEPARATOR ';'
+ 
++#if !defined CHAR_BIT && defined HAVE_LIMITS_H
++# include <limits.h>
++#endif
++
+ /* This describes the machine the compiler is hosted on.  */
+ #define HOST_BITS_PER_CHAR  CHAR_BIT
+ #define HOST_BITS_PER_SHORT (CHAR_BIT * SIZEOF_SHORT)
+@@ -52,6 +56,10 @@ Boston, MA 02111-1307, USA.  */
+ #endif
+ #endif /* no long long */
+ 
++#ifdef __MINGW64__
++# define HOST_BITS_PER_PTR  HOST_BITS_PER_LONGLONG
++#endif
++
+ /* Find the largest host integer type and set its size and type.  */
+ 
+ /* Use long long on the host if the target has a wider long type than
+@@ -79,6 +87,10 @@ Boston, MA 02111-1307, USA.  */
+ 
+ #ifndef HOST_BITS_PER_WIDE_INT
+ 
++#if defined __MINGW64__ && defined HOST_BITS_PER_LONGLONG && HOST_BITS_PER_LONGLONG > HOST_BITS_PER_LONG
++# define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_LONGLONG
++# define HOST_WIDE_INT __int64
++#else
+ # if HOST_BITS_PER_LONG > HOST_BITS_PER_INT
+ #  define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_LONG
+ #  define HOST_WIDE_INT long
+@@ -86,6 +98,7 @@ Boston, MA 02111-1307, USA.  */
+ #  define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_INT
+ #  define HOST_WIDE_INT int
+ # endif
++#endif
+ 
+ #endif /* ! HOST_BITS_PER_WIDE_INT */
+ 
+diff --git a/gcc/hwint.h b/gcc/hwint.h
+index 57d7edf..ea3b190 100644
+--- a/gcc/hwint.h
++++ b/gcc/hwint.h
+@@ -9,6 +9,10 @@
+ #ifndef GCC_HWINT_H
+ #define GCC_HWINT_H
+ 
++#if !defined CHAR_BIT && defined HAVE_LIMITS_H
++# include <limits.h>
++#endif
++
+ /* This describes the machine the compiler is hosted on.  */
+ #define HOST_BITS_PER_CHAR  CHAR_BIT
+ #define HOST_BITS_PER_SHORT (CHAR_BIT * SIZEOF_SHORT)
+@@ -28,6 +32,10 @@
+ # endif /* gcc */
+ #endif
+ #endif /* no long long */
++
++#ifdef __MINGW64__
++# define HOST_BITS_PER_PTR  HOST_BITS_PER_LONGLONG
++#endif
+ 
+ /* Find the largest host integer type and set its size and type.  */
+ 
+@@ -56,6 +64,10 @@
+ 
+ #ifndef HOST_BITS_PER_WIDE_INT
+ 
++#if defined __MINGW64__ && defined HOST_BITS_PER_LONGLONG && HOST_BITS_PER_LONGLONG > HOST_BITS_PER_LONG
++# define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_LONGLONG
++# define HOST_WIDE_INT long long
++#else
+ # if HOST_BITS_PER_LONG > HOST_BITS_PER_INT
+ #  define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_LONG
+ #  define HOST_WIDE_INT long
+@@ -63,6 +75,7 @@
+ #  define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_INT
+ #  define HOST_WIDE_INT int
+ # endif
++#endif
+ 
+ #endif /* ! HOST_BITS_PER_WIDE_INT */
+ 
+diff --git a/include/splay-tree.h b/include/splay-tree.h
+index 4b7a7bf..19d9171 100644
+--- a/include/splay-tree.h
++++ b/include/splay-tree.h
+@@ -40,8 +40,13 @@ extern "C" {
+    these types, if necessary.  These types should be sufficiently wide
+    that any pointer or scalar can be cast to these types, and then
+    cast back, without loss of precision.  */
++#ifdef __MINGW64__
++typedef unsigned long long int splay_tree_key;
++typedef unsigned long long int splay_tree_value;
++#else
+ typedef unsigned long int splay_tree_key;
+ typedef unsigned long int splay_tree_value;
++#endif
+ 
+ /* Forward declaration for a node in the tree.  */
+ typedef struct splay_tree_node_s *splay_tree_node;

--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -15,10 +15,17 @@ cd binutils-$BINUTILS_VERSION || { exit 1; }
 if [ -e ../../patches/binutils-$BINUTILS_VERSION-PS2.patch ]; then
 	cat ../../patches/binutils-$BINUTILS_VERSION-PS2.patch | patch -p1 || { exit 1; }
 fi
+cat ../../patches/binutils-$BINUTILS_VERSION-add-64bit-mingw-w64-toolchain-support.patch | patch -p1 || { exit 1; }
+
+OSVER=$(uname)
+if [ ${OSVER:0:10} == MINGW64_NT ]; then
+	TARG_XTRA_OPTS="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32"
+else
+	TARG_XTRA_OPTS=""
+fi
 
 ## Determine the maximum number of processes that Make can work with.
-OSVER=$(uname)
-if [ ${OSVER:0:10} == MINGW32_NT ]; then
+if [ ${OSVER:0:5} == MINGW ]; then
 	PROC_NR=$NUMBER_OF_PROCESSORS
 elif [ ${OSVER:0:6} == Darwin ]; then
 	PROC_NR=$(sysctl -n hw.ncpu)
@@ -35,9 +42,9 @@ for TARGET in "ee" "iop" "dvp"; do
 
 	## Configure the build.
 	if [ ${OSVER:0:6} == Darwin ]; then
-		CC=/usr/bin/gcc CXX=/usr/bin/g++ LD=/usr/bin/ld CFLAGS="-O0 -ansi -Wno-implicit-int -Wno-return-type" ../configure --quiet --disable-build-warnings --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
+		CC=/usr/bin/gcc CXX=/usr/bin/g++ LD=/usr/bin/ld CFLAGS="-O0 -ansi -Wno-implicit-int -Wno-return-type" ../configure --quiet --disable-build-warnings --prefix="$PS2DEV/$TARGET" --target="$TARGET" $TARG_XTRA_OPTS || { exit 1; }
 	else
-		../configure --quiet --disable-build-warnings --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
+		../configure --quiet --disable-build-warnings --prefix="$PS2DEV/$TARGET" --target="$TARGET" $TARG_XTRA_OPTS || { exit 1; }
 	fi
 
 	## Compile and install.

--- a/scripts/002-gcc-3.2.3-stage1.sh
+++ b/scripts/002-gcc-3.2.3-stage1.sh
@@ -16,17 +16,20 @@ cd gcc-$GCC_VERSION || { exit 1; }
 if [ -e ../../patches/gcc-$GCC_VERSION-PS2.patch ]; then
 	cat ../../patches/gcc-$GCC_VERSION-PS2.patch | patch -p1 || { exit 1; }
 fi
+cat ../../patches/gcc-$GCC_VERSION-add-64bit-mingw-w64-toolchain-support.patch | patch -p1 || { exit 1; }
 
 OSVER=$(uname)
 ## Apple needs to pretend to be linux
 if [ ${OSVER:0:6} == Darwin ]; then
 	TARG_XTRA_OPTS="--build=i386-linux-gnu --host=i386-linux-gnu"
+elif [ ${OSVER:0:10} == MINGW64_NT ]; then
+	TARG_XTRA_OPTS="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32"
 else
 	TARG_XTRA_OPTS=""
 fi
 
 ## Determine the maximum number of processes that Make can work with.
-if [ ${OSVER:0:10} == MINGW32_NT ]; then
+if [ ${OSVER:0:5} == MINGW ]; then
 	PROC_NR=$NUMBER_OF_PROCESSORS
 elif [ ${OSVER:0:6} == Darwin ]; then
 	PROC_NR=$(sysctl -n hw.ncpu)

--- a/scripts/003-newlib-1.10.0.sh
+++ b/scripts/003-newlib-1.10.0.sh
@@ -16,9 +16,15 @@ if [ -e ../../patches/newlib-$NEWLIB_VERSION-PS2.patch ]; then
 	cat ../../patches/newlib-$NEWLIB_VERSION-PS2.patch | patch -p1 || { exit 1; }
 fi
 
-## Determine the maximum number of processes that Make can work with.
 OSVER=$(uname)
-if [ ${OSVER:0:10} == MINGW32_NT ]; then
+if [ ${OSVER:0:10} == MINGW64_NT ]; then
+	TARG_XTRA_OPTS="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32"
+else
+	TARG_XTRA_OPTS=""
+fi
+
+## Determine the maximum number of processes that Make can work with.
+if [ ${OSVER:0:5} == MINGW ]; then
 	PROC_NR=$NUMBER_OF_PROCESSORS
 elif [ ${OSVER:0:6} == Darwin ]; then
 	PROC_NR=$(sysctl -n hw.ncpu)
@@ -31,7 +37,7 @@ TARGET="ee"
 mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 
 ## Configure the build.
-../configure --quiet --prefix="$PS2DEV/$TARGET" --target="$TARGET" || { exit 1; }
+../configure --quiet --prefix="$PS2DEV/$TARGET" --target="$TARGET" $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
 make --quiet clean && CPPFLAGS="-G0" make --quiet -j $PROC_NR && make --quiet install && make --quiet clean || { exit 1; }

--- a/scripts/004-gcc-3.2.3-stage2.sh
+++ b/scripts/004-gcc-3.2.3-stage2.sh
@@ -16,17 +16,20 @@ cd gcc-$GCC_VERSION || { exit 1; }
 if [ -e ../../patches/gcc-$GCC_VERSION-PS2.patch ]; then
 	cat ../../patches/gcc-$GCC_VERSION-PS2.patch | patch -p1 || { exit 1; }
 fi
+cat ../../patches/gcc-$GCC_VERSION-add-64bit-mingw-w64-toolchain-support.patch | patch -p1 || { exit 1; }
 
 OSVER=$(uname)
 ## Apple needs to pretend to be linux
 if [ ${OSVER:0:6} == Darwin ]; then
 	TARG_XTRA_OPTS="--build=i386-linux-gnu --host=i386-linux-gnu --enable-cxx-flags=-G0"
+elif [ ${OSVER:0:10} == MINGW64_NT ]; then
+	TARG_XTRA_OPTS="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --enable-cxx-flags=-G0"
 else
 	TARG_XTRA_OPTS="--enable-cxx-flags=-G0"
 fi
 
 ## Determine the maximum number of processes that Make can work with.
-if [ ${OSVER:0:10} == MINGW32_NT ]; then
+if [ ${OSVER:0:5} == MINGW ]; then
 	PROC_NR=$NUMBER_OF_PROCESSORS
 elif [ ${OSVER:0:6} == Darwin ]; then
 	PROC_NR=$(sysctl -n hw.ncpu)


### PR DESCRIPTION
By default, `configure` scripts of `binutils-2.14`, `gcc-3.2.3` and `newlib-1.10.0` are unable to autodetect the host triplet when run from 64-bit mingw shell (`mingw64.exe`) of 64-bit msys2 installation, so, it is required to pass the host triplet (`x86_64-w64-mingw32`) to configure script invocation, i.e.:

```
./configure --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32
```

And `gcc-3.2.3` requires some modifications related with the size of integral data types, as in its source code is assumed that:

1. The `long` integral data type is wide enough to do pointer or scalar type casting with no precision loss.
2. At host level, pointers have the same size as `long` integral data type.

So this explains why on 64-bit linux (data model: LP64) and 32-bit windows (data model: ILP32) platforms, GCC 3.2.3 can be built with no issues, while on 64-bit windows (data model: IL32P64) platform, GCC 3.2.3 can not be built (intermediate binaries such as `xgcc` keep throwing segfault), as the latter platform does not comply with the two premises mentioned above.