### PR TITLE
Update scripts to point to the v1.0 tag for ps2sdk and ps2client

### DIFF
--- a/scripts/005-ps2sdk.sh
+++ b/scripts/005-ps2sdk.sh
@@ -7,12 +7,13 @@ unset PS2SDKSRC
 
 ## Download the source code.
 if test ! -d "ps2sdk/.git"; then
-	git clone https://github.com/ps2dev/ps2sdk && cd ps2sdk || exit 1
+	git clone https://github.com/ps2dev/ps2sdk && cd ps2sdk || { exit 1; }
 else
-	cd ps2sdk &&
-		git pull && git fetch origin &&
-		git reset --hard origin/master || exit 1
+	cd ps2sdk && git pull && git fetch origin || { exit 1; }
 fi
+
+# We reset to the concrete tag
+git reset --hard v1.0 || { exit 1; }
 
 ## Determine the maximum number of processes that Make can work with.
 #OSVER=$(uname)

--- a/scripts/006-ps2client.sh
+++ b/scripts/006-ps2client.sh
@@ -4,12 +4,13 @@
 
 ## Download the source code.
 if test ! -d "ps2client/.git"; then
-	git clone https://github.com/ps2dev/ps2client && cd ps2client || exit 1
+	git clone https://github.com/ps2dev/ps2client && cd ps2client || { exit 1; }
 else
-	cd ps2client &&
-		git pull && git fetch origin &&
-		git reset --hard origin/master || exit 1
+	cd ps2client && git pull && git fetch origin || { exit 1; }
 fi
+
+# We reset to the concrete tag
+git reset --hard v1.0  || { exit 1; }
 
 ## Build and install.
 make --quiet clean && make --quiet && make --quiet install && make --quiet clean || { exit 1; }


### PR DESCRIPTION
This PR is the same that we did previously here https://github.com/ps2dev/ps2toolchain/pull/60
The reason why it is done again is that was pointing to the wrong target branch

Thanks again and sorry for it!