### PR TITLE
Automate generation of Docker Image

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -6,7 +6,6 @@ on:
   repository_dispatch:
     types: [run_build, run_release, run_build_ps2sdk, run_release_ps2sdk, run_build_ps2client, run_release_ps2client]
 
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -6,6 +6,7 @@ on:
   repository_dispatch:
     types: [run_build, run_release, run_build_ps2sdk, run_release_ps2sdk, run_build_ps2client, run_release_ps2client]
 
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,27 @@
+name: CI-Docker
+
+on:
+  push:
+  pull_request:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: alpine:latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Install Dependencies
+      run: |
+        apk add --no-cache make bash
+        apk add --no-cache --virtual .build-deps bash gcc musl-dev git make patch wget
+        apk add --no-cache --virtual .build-deps bash gcc musl-dev git make patch wget texinfo
+    
+    - name: Runs all the stages in the shell
+      run: |
+        export PS2DEV=$PWD/ps2dev
+        export PS2SDK=$PS2DEV/ps2sdk
+        export PATH=$PATH:$PS2DEV/bin:$PS2DEV/ee/bin:$PS2DEV/iop/bin:$PS2DEV/dvp/bin:$PS2SDK/bin
+        ./toolchain.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,3 +18,16 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ github.repository_owner }}/ps2dev
         tags: toolchain-latest
+    
+    - name: Send Compile action
+      run: |
+        export DISPATCH_ACTION="$(echo run_build)"
+        echo "::set-env name=NEW_DISPATCH_ACTION::$DISPATCH_ACTION"
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        repository: ${{ github.repository_owner }}/ps2sdk
+        token: ${{ secrets.DISPATCH_TOKEN }}
+        event-type: ${{ env.NEW_DISPATCH_ACTION }}
+        client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ github.repository_owner }}/ps2dev
-        tags: toolchain-latest
+        repository: ${{ env.GITHUB_REPOSITORY }}
+        tags: latest
     
     - name: Send Compile action
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,26 +2,19 @@ name: CI-Docker
 
 on:
   push:
-  pull_request:
-
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: alpine:latest
-
+  
     steps:
     - uses: actions/checkout@v2
-    
-    - name: Install Dependencies
-      run: |
-        apk add --no-cache make bash
-        apk add --no-cache --virtual .build-deps bash gcc musl-dev git make patch wget
-        apk add --no-cache --virtual .build-deps bash gcc musl-dev git make patch wget texinfo
-    
-    - name: Runs all the stages in the shell
-      run: |
-        export PS2DEV=$PWD/ps2dev
-        export PS2SDK=$PS2DEV/ps2sdk
-        export PATH=$PATH:$PS2DEV/bin:$PS2DEV/ee/bin:$PS2DEV/iop/bin:$PS2DEV/dvp/bin:$PS2SDK/bin
-        ./toolchain.sh
+
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: fjtrujy/ps2dev
+        tags: toolchain-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,5 +16,5 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: fjtrujy/ps2dev
+        repository: ${{ github.repository_owner }}/ps2dev
         tags: toolchain-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,14 @@ ENV PATH   $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/
 
 COPY . /src
 
-RUN \
-  apk add --no-cache make bash && \
-  apk add --no-cache --virtual .build-deps bash gcc musl-dev git make patch wget texinfo && \
-  cd /src && \
-  ./toolchain.sh 1 && \
-  ./toolchain.sh 2 && \
-  ./toolchain.sh 3 && \
-  ./toolchain.sh 4 && \
-  apk del .build-deps && \
-  rm -rf \
-    /src/* \
-    /tmp/*
+RUN apk add build-base git bash patch wget texinfo
+RUN cd /src && ls -l && ./toolchain.sh 1 && ./toolchain.sh 2 && ./toolchain.sh 3 && ./toolchain.sh 4
 
-WORKDIR /src
+# Second stage of Dockerfile
+FROM alpine:latest  
+
+ENV PS2DEV /usr/local/ps2dev
+ENV PS2SDK $PS2DEV/ps2sdk
+ENV PATH   $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/bin:${PS2SDK}/bin
+
+COPY --from=0 ${PS2DEV} ${PS2DEV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:latest
+
+ENV PS2DEV /usr/local/ps2dev
+ENV PS2SDK $PS2DEV/ps2sdk
+ENV PATH   $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/bin:${PS2SDK}/bin
+
+COPY . /src
+
+RUN \
+  apk add --no-cache make bash && \
+  apk add --no-cache --virtual .build-deps bash gcc musl-dev git make patch wget texinfo && \
+  cd /src && \
+  ./toolchain.sh 1 && \
+  ./toolchain.sh 2 && \
+  ./toolchain.sh 3 && \
+  ./toolchain.sh 4 && \
+  apk del .build-deps && \
+  rm -rf \
+    /src/* \
+    /tmp/*
+
+WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH   $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/
 COPY . /src
 
 RUN apk add build-base git bash patch wget texinfo
-RUN cd /src && ls -l && ./toolchain.sh 1 && ./toolchain.sh 2 && ./toolchain.sh 3 && ./toolchain.sh 4
+RUN cd /src && ./toolchain.sh 1 && ./toolchain.sh 2 && ./toolchain.sh 3 && ./toolchain.sh 4
 
 # Second stage of Dockerfile
 FROM alpine:latest  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![CI](https://github.com/ps2dev/ps2toolchain/workflows/CI/badge.svg)
+![CI-Docker](https://github.com/ps2dev/ps2toolchain/workflows/CI-Docker/badge.svg)
+
 # ps2toolchain
 
 This program will automatically build and install a compiler and other tools used in the creation of homebrew software for the Sony PlayStation® 2


### PR DESCRIPTION
## Descriptions
This PR integrates CI/CD in the repo. The main purpose of this CI/CD are:

- Now in advance, if a PR pending to be merged to `Master` is compiling.
- Generate pre-compiled toolchain for macOS and Ubuntu (for now). So lazy devs, can just go there and grab the toolchain without the need to compile in his machine.
- Generate a docker image `ps2dev/ps2toolchain:latest`, for being used latest by https://github.com/ps2dev/ps2sdk as based image.

Additionally, once the docker image is generated, it dispatches an action to `ps2sdk` to notify it for starting the CI/CD process.

In total there is a group of 4 PRs to implement the flow. If we want to have the CI/CD `green` since the beginning we need to merge them **in order and after the previous one finish the workflows**.

The proper order is:

1. https://github.com/ps2dev/ps2toolchain/pull/67
2. https://github.com/ps2dev/ps2sdk/pull/118
3. https://github.com/ps2dev/gsKit/pull/36
4. https://github.com/ps2dev/ps2sdk-ports/pull/50

Everything has been done, thanks to:
- @ooPo for giving me the grants in the `ps2dev` group in `GitHub`.
- @AKuHAK for giving me the grants to the `ps2dev` group in `Docker Hub`
- @rickgaiser for being involved in the whole process since the first minute.


