### PR TITLE
Add striping and release mode to binutils, GCC and newlib compilation

### DIFF
--- a/scripts/001-binutils-2.14.sh
+++ b/scripts/001-binutils-2.14.sh
@@ -47,7 +47,7 @@ for TARGET in "ee" "iop" "dvp"; do
 	fi
 
 	## Compile and install.
-	make --quiet clean && make --quiet -j $PROC_NR CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=0" && make --quiet install && make --quiet clean || { exit 1; }
+	make --quiet clean && make --quiet -j $PROC_NR CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=0 -O2" LDFLAGS="$LDFLAGS -s" && make --quiet install && make --quiet clean || { exit 1; }
 
 	## Exit the build directory.
 	cd .. || { exit 1; }

--- a/scripts/002-gcc-3.2.3-stage1.sh
+++ b/scripts/002-gcc-3.2.3-stage1.sh
@@ -51,7 +51,7 @@ for TARGET in "ee" "iop"; do
 	fi
 
 	## Compile and install.
-	make --quiet clean && make --quiet -j $PROC_NR && make --quiet install && make --quiet clean || { exit 1; }
+	make --quiet clean && make --quiet -j $PROC_NR CFLAGS="$CFLAGS -O2" LDFLAGS="$LDFLAGS -s" && make --quiet install && make --quiet clean || { exit 1; }
 
 	## Exit the build directory.
 	cd .. || { exit 1; }

--- a/scripts/003-newlib-1.14.0.sh
+++ b/scripts/003-newlib-1.14.0.sh
@@ -40,4 +40,4 @@ mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 ../configure --quiet --prefix="$PS2DEV/$TARGET" --target="$TARGET" $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet clean && CPPFLAGS="-G0" make --quiet -j $PROC_NR && make --quiet install && make --quiet clean || { exit 1; }
+make --quiet clean && CPPFLAGS="-G0" make --quiet -j $PROC_NR CFLAGS="$CFLAGS -O2" LDFLAGS="$LDFLAGS -s" && make --quiet install && make --quiet clean || { exit 1; }

--- a/scripts/004-gcc-3.2.3-stage2.sh
+++ b/scripts/004-gcc-3.2.3-stage2.sh
@@ -46,4 +46,4 @@ mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
 ../configure --quiet --prefix="$PS2DEV/$TARGET" --target="$TARGET" --enable-languages="c,c++" --with-newlib --with-headers="$PS2DEV/$TARGET/$TARGET/include" $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet clean && make --quiet -j $PROC_NR && make --quiet install && make --quiet clean || { exit 1; }
+make --quiet clean && make --quiet -j $PROC_NR CFLAGS="$CFLAGS -O2" LDFLAGS="$LDFLAGS -s" && make --quiet install && make --quiet clean || { exit 1; }


### PR DESCRIPTION
Doing this we get a reduction of the size of the toolchain, plus most probably some speed up compiling PS2 specific code.

Thanks