### PR TITLE
WIP: Update BinUtils to 2.15

### DIFF
--- a/patches/binutils-2.15-PS2.patch
+++ b/patches/binutils-2.15-PS2.patch
@@ -1,40 +1,38 @@
 diff --git a/Makefile.in b/Makefile.in
-index 561dc7612f..0ec7e3c5bf 100644
+index 2acda0180b..37b9bc7bbd 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -191,13 +191,13 @@ M4 = `if [ -f $$r/m4/m4 ] ; \
- 	then echo $$r/m4/m4 ; \
+@@ -180,12 +180,12 @@ M4 = `if [ -f $$r/m4/m4 ] ; \
  	else echo ${DEFAULT_M4} ; fi`
  
--# For an installed makeinfo, we require it to be from texinfo 4 or
+ # For an installed makeinfo, we require it to be from texinfo 4.2 or
 -# higher, else we use the "missing" dummy.
-+# For an installed makeinfo, we require it to be texinfo 4. texinfo >= 5 is more strict
 +# and breaks the compilation. Disable makeinfo in that case by using the "missing" dummy.
  MAKEINFO=@MAKEINFO@
  USUAL_MAKEINFO = `if [ -f $$r/texinfo/makeinfo/makeinfo ] ; \
  	then echo $$r/texinfo/makeinfo/makeinfo ; \
  	else if (makeinfo --version \
--	  | egrep 'texinfo[^0-9]*([1-3][0-9]|[4-9])') >/dev/null 2>&1; \
+-	  | egrep 'texinfo[^0-9]*([1-3][0-9]|4\.[2-9]|[5-9])') >/dev/null 2>&1; \
 +	  | egrep 'texinfo[^0-9]*([1-3][0-9]|[4])') >/dev/null 2>&1; \
          then echo makeinfo; else echo $$s/missing makeinfo; fi; fi`
  
  # This just becomes part of the MAKEINFO definition passed down to
 diff --git a/bfd/archures.c b/bfd/archures.c
-index 3d473c3b8a..2c6cbfca9a 100644
+index f8aeeef883..d8ff8a5655 100644
 --- a/bfd/archures.c
 +++ b/bfd/archures.c
-@@ -137,6 +137,7 @@ DESCRIPTION
+@@ -138,6 +138,7 @@ DESCRIPTION
  .#define bfd_mach_mips5000		5000
  .#define bfd_mach_mips5400		5400
  .#define bfd_mach_mips5500		5500
 +.#define bfd_mach_mips5900		5900
  .#define bfd_mach_mips6000		6000
+ .#define bfd_mach_mips7000		7000
  .#define bfd_mach_mips8000		8000
- .#define bfd_mach_mips10000		10000
-@@ -147,6 +148,11 @@ DESCRIPTION
- .#define bfd_mach_mipsisa32             32
+@@ -150,6 +151,11 @@ DESCRIPTION
  .#define bfd_mach_mipsisa32r2           33
  .#define bfd_mach_mipsisa64             64
+ .#define bfd_mach_mipsisa64r2           65
 +.#define bfd_mach_dvp_dma		42000
 +.#define bfd_mach_dvp_vif		42001
 +.#define bfd_mach_dvp_vu		42002
@@ -44,21 +42,21 @@ index 3d473c3b8a..2c6cbfca9a 100644
  .#define bfd_mach_i386_i386 1
  .#define bfd_mach_i386_i8086 2
 diff --git a/bfd/bfd-in2.h b/bfd/bfd-in2.h
-index 9b6b5a3937..3fde2a01eb 100644
+index 2464d27e39..ee7e23d880 100644
 --- a/bfd/bfd-in2.h
 +++ b/bfd/bfd-in2.h
-@@ -1605,6 +1605,7 @@ enum bfd_architecture
+@@ -1536,6 +1536,7 @@ enum bfd_architecture
  #define bfd_mach_mips5000              5000
  #define bfd_mach_mips5400              5400
  #define bfd_mach_mips5500              5500
 +#define bfd_mach_mips5900              5900
  #define bfd_mach_mips6000              6000
+ #define bfd_mach_mips7000              7000
  #define bfd_mach_mips8000              8000
- #define bfd_mach_mips10000             10000
-@@ -1615,6 +1616,11 @@ enum bfd_architecture
- #define bfd_mach_mipsisa32             32
+@@ -1548,6 +1549,11 @@ enum bfd_architecture
  #define bfd_mach_mipsisa32r2           33
  #define bfd_mach_mipsisa64             64
+ #define bfd_mach_mipsisa64r2           65
 +#define bfd_mach_dvp_dma               42000
 +#define bfd_mach_dvp_vif               42001
 +#define bfd_mach_dvp_vu                42002
@@ -67,17 +65,17 @@ index 9b6b5a3937..3fde2a01eb 100644
    bfd_arch_i386,      /* Intel 386 */
  #define bfd_mach_i386_i386 1
  #define bfd_mach_i386_i8086 2
-@@ -2374,6 +2380,7 @@ to compensate for the borrow when the low bits are added.  */
+@@ -2304,6 +2310,7 @@ to compensate for the borrow when the low bits are added.  */
    BFD_RELOC_MIPS_REL16,
    BFD_RELOC_MIPS_RELGOT,
    BFD_RELOC_MIPS_JALR,
 +  BFD_RELOC_MIPS15_S3,
  
+ 
  /* Fujitsu Frv Relocations.  */
-   BFD_RELOC_FRV_LABEL16,
-@@ -2386,6 +2393,21 @@ to compensate for the borrow when the low bits are added.  */
-   BFD_RELOC_FRV_GPRELHI,
-   BFD_RELOC_FRV_GPRELLO,
+@@ -2359,6 +2366,21 @@ in the instruction.  */
+ /* Adjust by program base.  */
+   BFD_RELOC_MN10300_RELATIVE,
  
 +/* MIPS DVP Relocations. 
 +This is an 11-bit pc relative reloc.  The recorded address is for the 
@@ -98,10 +96,10 @@ index 9b6b5a3937..3fde2a01eb 100644
  /* i386/elf relocations  */
    BFD_RELOC_386_GOT32,
 diff --git a/bfd/config.bfd b/bfd/config.bfd
-index fa2e9ae479..339ed25228 100755
+index 1428831c15..88ac364a50 100644
 --- a/bfd/config.bfd
 +++ b/bfd/config.bfd
-@@ -63,6 +63,9 @@ z8k*)	         targ_archs=bfd_z8k_arch ;;
+@@ -78,6 +78,9 @@ am33_2.0)        targ_archs=bfd_mn10300_arch ;;
  *)	         targ_archs=bfd_${targ_cpu}_arch ;;
  esac
  
@@ -111,18 +109,19 @@ index fa2e9ae479..339ed25228 100755
  
  # WHEN ADDING ENTRIES TO THIS MATRIX:
  #  Make sure that the left side always has two dashes.  Otherwise you
-@@ -323,6 +326,10 @@ case "${targ}" in
-     targ_defvec=bfd_elf32_frv_vec
+@@ -344,6 +347,11 @@ case "${targ}" in
+     targ_selvecs=bfd_elf32_frv_vec
      ;;
  
 +  dvp-*-*)
 +    targ_defvec=bfd_elf32_littlemips_vec
 +    targ_selvecs="bfd_elf64_littlemips_vec"
 +    ;;
- 
++
    h8300*-*-elf)
      targ_defvec=bfd_elf32_h8300_vec
-@@ -781,6 +788,10 @@ case "${targ}" in
+     targ_underscore=yes
+@@ -814,6 +822,10 @@ case "${targ}" in
      targ_defvec=bfd_elf32_bigmips_vec
      targ_selvecs="bfd_elf32_littlemips_vec bfd_elf64_bigmips_vec bfd_elf64_littlemips_vec"
      ;;
@@ -134,10 +133,10 @@ index fa2e9ae479..339ed25228 100755
      targ_defvec=bfd_elf32_bigmips_vec
      targ_selvecs="bfd_elf32_littlemips_vec bfd_elf64_bigmips_vec bfd_elf64_littlemips_vec"
 diff --git a/bfd/configure b/bfd/configure
-index 5dca0f1944..26532c21cc 100755
+index 46c8170edd..c2640b7bb9 100755
 --- a/bfd/configure
 +++ b/bfd/configure
-@@ -6046,6 +6046,8 @@ for i in $selvecs ; do
+@@ -6222,6 +6222,8 @@ for i in $selvecs ; do
  done
  selvecs="$f"
  
@@ -147,10 +146,10 @@ index 5dca0f1944..26532c21cc 100755
  # uniq the associated vectors in all the configured targets.
  f=""
 diff --git a/bfd/configure.in b/bfd/configure.in
-index 7774871f96..4300f4ac17 100644
+index 71f41f4296..43e9d8562d 100644
 --- a/bfd/configure.in
 +++ b/bfd/configure.in
-@@ -508,6 +508,8 @@ for i in $selvecs ; do
+@@ -531,6 +531,8 @@ for i in $selvecs ; do
  done
  selvecs="$f"
  
@@ -160,21 +159,21 @@ index 7774871f96..4300f4ac17 100644
  # uniq the associated vectors in all the configured targets.
  f=""
 diff --git a/bfd/cpu-mips.c b/bfd/cpu-mips.c
-index 13355c5c5a..b0b3220bbb 100644
+index 01ecc4e40d..5b83cb7ff4 100644
 --- a/bfd/cpu-mips.c
 +++ b/bfd/cpu-mips.c
-@@ -75,6 +75,7 @@ enum
+@@ -73,6 +73,7 @@ enum
    I_mips5000,
    I_mips5400,
    I_mips5500,
 +  I_mips5900,
    I_mips6000,
+   I_mips7000,
    I_mips8000,
-   I_mips10000,
 @@ -84,6 +85,10 @@ enum
-   I_mipsisa32,
    I_mipsisa32r2,
    I_mipsisa64,
+   I_mipsisa64r2,
 +  I_dvp_dma,
 +  I_dvp_vif,
 +  I_dvp_vu,
@@ -188,12 +187,12 @@ index 13355c5c5a..b0b3220bbb 100644
    N (64, 64, bfd_mach_mips5500, "mips:5500",      FALSE, NN(I_mips5500)),
 +  N (64, 32, bfd_mach_mips5900, "mips:5900",      FALSE, NN(I_mips5900)),
    N (32, 32, bfd_mach_mips6000, "mips:6000",      FALSE, NN(I_mips6000)),
+   N (64, 64, bfd_mach_mips7000, "mips:7000",      FALSE, NN(I_mips7000)),
    N (64, 64, bfd_mach_mips8000, "mips:8000",      FALSE, NN(I_mips8000)),
-   N (64, 64, bfd_mach_mips10000,"mips:10000",     FALSE, NN(I_mips10000)),
-@@ -114,6 +120,10 @@ static const bfd_arch_info_type arch_info_struct[] =
-   N (32, 32, bfd_mach_mipsisa32,  "mips:isa32",   FALSE, NN(I_mipsisa32)),
+@@ -116,6 +122,10 @@ static const bfd_arch_info_type arch_info_struct[] =
    N (32, 32, bfd_mach_mipsisa32r2,"mips:isa32r2", FALSE, NN(I_mipsisa32r2)),
    N (64, 64, bfd_mach_mipsisa64,  "mips:isa64",   FALSE, NN(I_mipsisa64)),
+   N (64, 64, bfd_mach_mipsisa64r2,"mips:isa64r2", FALSE, NN(I_mipsisa64r2)),
 +  N (32, 32, bfd_mach_dvp_dma, "dvp:dma",         FALSE, NN(I_dvp_dma)),
 +  N (32, 32, bfd_mach_dvp_vif, "dvp:vif",         FALSE, NN(I_dvp_vif)),
 +  N (32, 32, bfd_mach_dvp_vu, "dvp:vu",           FALSE, NN(I_dvp_vu)),
@@ -202,19 +201,19 @@ index 13355c5c5a..b0b3220bbb 100644
  };
  
 diff --git a/bfd/elf.c b/bfd/elf.c
-index 7e1bacd286..145d23f0bd 100644
+index a14fd35148..d26c2b9cc2 100644
 --- a/bfd/elf.c
 +++ b/bfd/elf.c
-@@ -2214,7 +2214,7 @@ _bfd_elf_make_section_from_phdr (abfd, hdr, index, typename)
-   newsect->_raw_size = hdr->p_filesz;
+@@ -2209,7 +2209,7 @@ _bfd_elf_make_section_from_phdr (bfd *abfd,
    newsect->filepos = hdr->p_offset;
    newsect->flags |= SEC_HAS_CONTENTS;
+   newsect->alignment_power = bfd_log2 (hdr->p_align);
 -  if (hdr->p_type == PT_LOAD)
 +  if (hdr->p_type == PT_LOAD || hdr->p_type == PT_MIPS_IRXHDR)
      {
        newsect->flags |= SEC_ALLOC;
        newsect->flags |= SEC_LOAD;
-@@ -2244,7 +2244,7 @@ _bfd_elf_make_section_from_phdr (abfd, hdr, index, typename)
+@@ -2239,7 +2239,7 @@ _bfd_elf_make_section_from_phdr (bfd *abfd,
        newsect->vma = hdr->p_vaddr + hdr->p_filesz;
        newsect->lma = hdr->p_paddr + hdr->p_filesz;
        newsect->_raw_size = hdr->p_memsz - hdr->p_filesz;
@@ -223,7 +222,7 @@ index 7e1bacd286..145d23f0bd 100644
  	{
  	  newsect->flags |= SEC_ALLOC;
  	  if (hdr->p_flags & PF_X)
-@@ -3744,7 +3744,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3773,7 +3773,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
        else
  	p->p_paddr = m->sections[0]->lma;
  
@@ -232,7 +231,7 @@ index 7e1bacd286..145d23f0bd 100644
  	  && (abfd->flags & D_PAGED) != 0)
  	p->p_align = bed->maxpagesize;
        else if (m->count == 0)
-@@ -3765,7 +3765,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3794,7 +3794,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  	  p->p_memsz = bed->s->sizeof_ehdr;
  	  if (m->count > 0)
  	    {
@@ -241,7 +240,7 @@ index 7e1bacd286..145d23f0bd 100644
  
  	      if (p->p_vaddr < (bfd_vma) off)
  		{
-@@ -3780,7 +3780,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3809,7 +3809,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  	      if (! m->p_paddr_valid)
  		p->p_paddr -= off;
  	    }
@@ -250,7 +249,7 @@ index 7e1bacd286..145d23f0bd 100644
  	    {
  	      filehdr_vaddr = p->p_vaddr;
  	      filehdr_paddr = p->p_paddr;
-@@ -3794,7 +3794,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3823,7 +3823,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  
  	  if (m->includes_filehdr)
  	    {
@@ -259,7 +258,7 @@ index 7e1bacd286..145d23f0bd 100644
  		{
  		  phdrs_vaddr = p->p_vaddr + bed->s->sizeof_ehdr;
  		  phdrs_paddr = p->p_paddr + bed->s->sizeof_ehdr;
-@@ -3812,7 +3812,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3841,7 +3841,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  		    p->p_paddr -= off - p->p_offset;
  		}
  
@@ -268,7 +267,7 @@ index 7e1bacd286..145d23f0bd 100644
  		{
  		  phdrs_vaddr = p->p_vaddr;
  		  phdrs_paddr = p->p_paddr;
-@@ -3825,7 +3825,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3854,7 +3854,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  	  p->p_memsz += alloc * bed->s->sizeof_phdr;
  	}
  
@@ -277,7 +276,7 @@ index 7e1bacd286..145d23f0bd 100644
  	  || (p->p_type == PT_NOTE && bfd_get_format (abfd) == bfd_core))
  	{
  	  if (! m->includes_filehdr && ! m->includes_phdrs)
-@@ -3860,7 +3860,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3889,7 +3889,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  	      bfd_vma adjust = sec->lma - (p->p_paddr + p->p_memsz);
  
  	      p->p_memsz += adjust;
@@ -286,7 +285,7 @@ index 7e1bacd286..145d23f0bd 100644
  		  || (p->p_type == PT_NOTE
  		      && bfd_get_format (abfd) == bfd_core))
  		{
-@@ -3872,7 +3872,7 @@ assign_file_positions_for_segments (abfd)
+@@ -3901,7 +3901,7 @@ assign_file_positions_for_segments (bfd *abfd, struct bfd_link_info *link_info)
  		p->p_filesz += adjust;
  	    }
  
@@ -295,7 +294,7 @@ index 7e1bacd286..145d23f0bd 100644
  	    {
  	      bfd_signed_vma adjust;
  
-@@ -3977,7 +3977,8 @@ Error: First section in segment (%s) starts at 0x%x whereas the segment starts a
+@@ -4008,7 +4008,8 @@ Error: First section in segment (%s) starts at 0x%x whereas the segment starts a
  		}
  
  	      if (align > p->p_align
@@ -305,7 +304,7 @@ index 7e1bacd286..145d23f0bd 100644
  		p->p_align = align;
  	    }
  
-@@ -3998,7 +3999,7 @@ Error: First section in segment (%s) starts at 0x%x whereas the segment starts a
+@@ -4029,7 +4030,7 @@ Error: First section in segment (%s) starts at 0x%x whereas the segment starts a
         m != NULL;
         m = m->next, p++)
      {
@@ -315,19 +314,19 @@ index 7e1bacd286..145d23f0bd 100644
  	  BFD_ASSERT (! m->includes_filehdr && ! m->includes_phdrs);
  	  p->p_offset = m->sections[0]->filepos;
 diff --git a/bfd/elf32-mips.c b/bfd/elf32-mips.c
-index adf057b40d..d4de4a7427 100644
+index a0480f0970..fe49cc7923 100644
 --- a/bfd/elf32-mips.c
 +++ b/bfd/elf32-mips.c
-@@ -75,6 +75,8 @@ static bfd_reloc_status_type mips16_jump_reloc
-   PARAMS ((bfd *, arelent *, asymbol *, PTR, asection *, bfd *, char **));
+@@ -71,6 +71,8 @@ static bfd_reloc_status_type mips16_jump_reloc
+   (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
  static bfd_reloc_status_type mips16_gprel_reloc
-   PARAMS ((bfd *, arelent *, asymbol *, PTR, asection *, bfd *, char **));
+   (bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
 +static bfd_reloc_status_type dvp_u15_s3_reloc
 +  PARAMS ((bfd *, arelent *, asymbol *, PTR, asection *, bfd *, char **));
  static bfd_reloc_status_type mips_elf_final_gp
-   PARAMS ((bfd *, asymbol *, bfd_boolean, char **, bfd_vma *));
+   (bfd *, asymbol *, bfd_boolean, char **, bfd_vma *);
  static bfd_boolean mips_elf_assign_gp
-@@ -603,6 +605,81 @@ static reloc_howto_type elf_mips16_gprel_howto =
+@@ -599,6 +601,81 @@ static reloc_howto_type elf_mips16_gprel_howto =
  	 0x07ff001f,	        /* dst_mask */
  	 FALSE);		/* pcrel_offset */
  
@@ -409,8 +408,8 @@ index adf057b40d..d4de4a7427 100644
  /* GNU extensions for embedded-pic.  */
  /* High 16 bits of symbol value, pc-relative.  */
  static reloc_howto_type elf_mips_gnu_rel_hi16 =
-@@ -1381,6 +1458,58 @@ mips16_gprel_reloc (abfd, reloc_entry, symbol, data, input_section,
-   return ret;
+@@ -1062,6 +1139,58 @@ mips16_gprel_reloc (bfd *abfd, arelent *reloc_entry, asymbol *symbol,
+   return bfd_reloc_ok;
  }
  
 +/* Handle a dvp R_MIPS_DVP_U15_S3 reloc. 
@@ -468,7 +467,7 @@ index adf057b40d..d4de4a7427 100644
  /* A mapping from BFD reloc types to MIPS ELF reloc types.  */
  
  struct elf_reloc_map {
-@@ -1451,6 +1580,16 @@ bfd_elf32_bfd_reloc_type_lookup (abfd, code)
+@@ -1130,6 +1259,16 @@ bfd_elf32_bfd_reloc_type_lookup (bfd *abfd, bfd_reloc_code_real_type code)
        return &elf_mips16_jump_howto;
      case BFD_RELOC_MIPS16_GPREL:
        return &elf_mips16_gprel_howto;
@@ -485,7 +484,7 @@ index adf057b40d..d4de4a7427 100644
      case BFD_RELOC_VTABLE_INHERIT:
        return &elf_mips_gnu_vtinherit_howto;
      case BFD_RELOC_VTABLE_ENTRY:
-@@ -1481,6 +1620,16 @@ mips_elf32_rtype_to_howto (r_type, rela_p)
+@@ -1159,6 +1298,16 @@ mips_elf32_rtype_to_howto (unsigned int r_type,
        return &elf_mips16_jump_howto;
      case R_MIPS16_GPREL:
        return &elf_mips16_gprel_howto;
@@ -502,31 +501,32 @@ index adf057b40d..d4de4a7427 100644
      case R_MIPS_GNU_VTINHERIT:
        return &elf_mips_gnu_vtinherit_howto;
      case R_MIPS_GNU_VTENTRY:
-diff --git a/bfd/elflink.h b/bfd/elflink.h
-index 9b7bcff820..ffe02e663e 100644
---- a/bfd/elflink.h
-+++ b/bfd/elflink.h
-@@ -7238,9 +7238,18 @@ elf_link_input_bfd (finfo, input_bfd)
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 6628db34cc..50fe0ece46 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -6747,10 +6747,19 @@ elf_link_input_bfd (struct elf_final_link_info *finfo, bfd *input_bfd)
  			 elf_link_output_extsym that this symbol is
  			 used by a reloc.  */
  		      BFD_ASSERT (rh->indx < 0);
-+		      if (elf_elfheader (output_bfd)->e_type != ET_IRX
++			  if (elf_elfheader (output_bfd)->e_type != ET_IRX
 +			  || finfo->info->strip != strip_all)
 +			{
  		      rh->indx = -2;
--
+ 
  		      *rel_hash = rh;
+-
 +			}
 +		      else
 +			{
-+			  irela->r_info =
-+			    ELF_R_INFO (0, ELF_R_TYPE (irela->r_info)); 
++			  irela->r_info = ((bfd_vma) 0 << r_sym_shift
++				   | (irela->r_info & r_type_mask));
 +			  *rel_hash = NULL;
 +			}
- 
  		      continue;
  		    }
-@@ -7269,7 +7278,8 @@ elf_link_input_bfd (finfo, input_bfd)
+ 
+@@ -6778,7 +6787,8 @@ elf_link_input_bfd (struct elf_final_link_info *finfo, bfd *input_bfd)
  		      else
  			{
  			  r_symndx = sec->output_section->target_index;
@@ -537,10 +537,10 @@ index 9b7bcff820..ffe02e663e 100644
  
  		      /* Adjust the addend according to where the
 diff --git a/bfd/elfxx-mips.c b/bfd/elfxx-mips.c
-index 9d86f3be47..ecb0df8370 100644
+index 8fb20d8a7e..32942cda77 100644
 --- a/bfd/elfxx-mips.c
 +++ b/bfd/elfxx-mips.c
-@@ -4064,6 +4064,9 @@ _bfd_elf_mips_mach (flags)
+@@ -4088,6 +4088,9 @@ _bfd_elf_mips_mach (flagword flags)
      case E_MIPS_MACH_5500:
        return bfd_mach_mips5500;
  
@@ -550,7 +550,7 @@ index 9d86f3be47..ecb0df8370 100644
      case E_MIPS_MACH_SB1:
        return bfd_mach_mips_sb1;
  
-@@ -4379,6 +4382,10 @@ _bfd_mips_elf_section_from_shdr (abfd, hdr, name)
+@@ -4420,6 +4423,10 @@ _bfd_mips_elf_section_from_shdr (bfd *abfd, Elf_Internal_Shdr *hdr,
       probably get away with this.  */
    switch (hdr->sh_type)
      {
@@ -561,7 +561,7 @@ index 9d86f3be47..ecb0df8370 100644
      case SHT_MIPS_LIBLIST:
        if (strcmp (name, ".liblist") != 0)
  	return FALSE;
-@@ -4436,6 +4443,15 @@ _bfd_mips_elf_section_from_shdr (abfd, hdr, name)
+@@ -4477,6 +4484,15 @@ _bfd_mips_elf_section_from_shdr (bfd *abfd, Elf_Internal_Shdr *hdr,
  		      sizeof ".MIPS.post_rel" - 1) != 0)
  	return FALSE;
        break;
@@ -577,7 +577,7 @@ index 9d86f3be47..ecb0df8370 100644
      default:
        return FALSE;
      }
-@@ -4540,7 +4556,25 @@ _bfd_mips_elf_fake_sections (abfd, hdr, sec)
+@@ -4577,7 +4593,25 @@ _bfd_mips_elf_fake_sections (bfd *abfd, Elf_Internal_Shdr *hdr, asection *sec)
  
    name = bfd_get_section_name (abfd, sec);
  
@@ -604,7 +604,7 @@ index 9d86f3be47..ecb0df8370 100644
      {
        hdr->sh_type = SHT_MIPS_LIBLIST;
        hdr->sh_info = sec->_raw_size / sizeof (Elf32_Lib);
-@@ -4639,6 +4673,17 @@ _bfd_mips_elf_fake_sections (abfd, hdr, sec)
+@@ -4676,6 +4710,17 @@ _bfd_mips_elf_fake_sections (bfd *abfd, Elf_Internal_Shdr *hdr, asection *sec)
        hdr->sh_flags |= SHF_ALLOC;
        hdr->sh_entsize = 8;
      }
@@ -620,9 +620,9 @@ index 9d86f3be47..ecb0df8370 100644
 +                    sizeof (SHNAME_DVP_OVERLAY_PREFIX) - 1) == 0)
 +    hdr->sh_type = SHT_DVP_OVERLAY;
  
-   /* The generic elf_fake_sections will set up REL_HDR using the
-      default kind of relocations.  But, we may actually need both
-@@ -7300,6 +7345,10 @@ mips_set_isa_flags (abfd)
+   /* The generic elf_fake_sections will set up REL_HDR using the default
+    kind of relocations.  We used to set up a second header for the
+@@ -7142,6 +7187,10 @@ mips_set_isa_flags (bfd *abfd)
        val = E_MIPS_ARCH_4 | E_MIPS_MACH_5500;
        break;
  
@@ -631,9 +631,9 @@ index 9d86f3be47..ecb0df8370 100644
 +      break;
 +
      case bfd_mach_mips5000:
+     case bfd_mach_mips7000:
      case bfd_mach_mips8000:
-     case bfd_mach_mips10000:
-@@ -7418,6 +7467,13 @@ _bfd_mips_elf_final_write_processing (abfd, linker)
+@@ -7264,6 +7313,13 @@ _bfd_mips_elf_final_write_processing (bfd *abfd,
  	  (*hdrpp)->sh_link = elf_section_data (sec)->this_idx;
  	  break;
  
@@ -647,7 +647,7 @@ index 9d86f3be47..ecb0df8370 100644
  	}
      }
  }
-@@ -9112,6 +9168,7 @@ static const struct mips_mach_extension mips_mach_extensions[] = {
+@@ -8892,6 +8948,7 @@ static const struct mips_mach_extension mips_mach_extensions[] = {
    { bfd_mach_mips4300, bfd_mach_mips4000 },
    { bfd_mach_mips4100, bfd_mach_mips4000 },
    { bfd_mach_mips4010, bfd_mach_mips4000 },
@@ -655,7 +655,7 @@ index 9d86f3be47..ecb0df8370 100644
  
    /* MIPS32 extensions.  */
    { bfd_mach_mipsisa32r2, bfd_mach_mipsisa32 },
-@@ -9276,7 +9333,7 @@ _bfd_mips_elf_merge_private_bfd_data (ibfd, obfd)
+@@ -9054,7 +9111,7 @@ _bfd_mips_elf_merge_private_bfd_data (bfd *ibfd, bfd *obfd)
      {
        (*_bfd_error_handler)
  	(_("%s: linking 32-bit code with 64-bit code"),
@@ -665,44 +665,46 @@ index 9d86f3be47..ecb0df8370 100644
      }
    else if (!mips_mach_extends_p (bfd_get_mach (ibfd), bfd_get_mach (obfd)))
 diff --git a/bfd/libbfd.h b/bfd/libbfd.h
-index 9bbdebd218..fdef23cbe4 100644
+index 62043f3860..928f28b744 100644
 --- a/bfd/libbfd.h
 +++ b/bfd/libbfd.h
-@@ -872,6 +872,7 @@ static const char *const bfd_reloc_code_real_names[] = { "@@uninitialized@@",
+@@ -860,7 +860,8 @@ static const char *const bfd_reloc_code_real_names[] = { "@@uninitialized@@",
    "BFD_RELOC_MIPS_REL16",
    "BFD_RELOC_MIPS_RELGOT",
    "BFD_RELOC_MIPS_JALR",
+-
 +  "BFD_RELOC_MIPS15_S3",
++  
    "BFD_RELOC_FRV_LABEL16",
    "BFD_RELOC_FRV_LABEL24",
    "BFD_RELOC_FRV_LO16",
-@@ -881,6 +882,10 @@ static const char *const bfd_reloc_code_real_names[] = { "@@uninitialized@@",
-   "BFD_RELOC_FRV_GPREL32",
-   "BFD_RELOC_FRV_GPRELHI",
-   "BFD_RELOC_FRV_GPRELLO",
+@@ -884,6 +885,10 @@ static const char *const bfd_reloc_code_real_names[] = { "@@uninitialized@@",
+   "BFD_RELOC_FRV_GOTOFF12",
+   "BFD_RELOC_FRV_GOTOFFHI",
+   "BFD_RELOC_FRV_GOTOFFLO",
 +  "BFD_RELOC_MIPS_DVP_11_PCREL",
 +  "BFD_RELOC_MIPS_DVP_27_S4",
 +  "BFD_RELOC_MIPS_DVP_11_S4",
 +  "BFD_RELOC_MIPS_DVP_U15_S3",
  
-   "BFD_RELOC_386_GOT32",
-   "BFD_RELOC_386_PLT32",
+   "BFD_RELOC_MN10300_GOTOFF24",
+   "BFD_RELOC_MN10300_GOT32",
 diff --git a/bfd/reloc.c b/bfd/reloc.c
-index 6aea881f38..3aa7853847 100644
+index 9bffaa3658..644ffdb2e0 100644
 --- a/bfd/reloc.c
 +++ b/bfd/reloc.c
-@@ -2128,6 +2128,8 @@ ENUMX
+@@ -2117,6 +2117,8 @@ ENUMX
    BFD_RELOC_MIPS_RELGOT
  ENUMX
    BFD_RELOC_MIPS_JALR
 +ENUMX
 +  BFD_RELOC_MIPS15_S3
- COMMENT
- ENUM
-   BFD_RELOC_FRV_LABEL16
-@@ -2155,6 +2157,27 @@ ENUMDOC
+ ENUMDOC
    MIPS ELF relocations.
- 
+ COMMENT
+@@ -2207,6 +2209,27 @@ ENUM
+ ENUMDOC
+   Adjust by program base.
  COMMENT
 +ENUM 
 +  BFD_RELOC_MIPS_DVP_11_PCREL 
@@ -729,10 +731,10 @@ index 6aea881f38..3aa7853847 100644
  ENUM
    BFD_RELOC_386_GOT32
 diff --git a/config.sub b/config.sub
-index fe4f1edf3c..118a5a30dc 100755
+index d2e3557ac4..8fc7db5360 100755
 --- a/config.sub
 +++ b/config.sub
-@@ -250,6 +250,7 @@ case $basic_machine in
+@@ -253,6 +253,7 @@ case $basic_machine in
  	| mipsisa64sb1 | mipsisa64sb1el \
  	| mipsisa64sr71k | mipsisa64sr71kel \
  	| mipstx39 | mipstx39el \
@@ -740,16 +742,15 @@ index fe4f1edf3c..118a5a30dc 100755
  	| mn10200 | mn10300 \
  	| msp430 \
  	| ns16k | ns32k \
-@@ -261,7 +262,7 @@ case $basic_machine in
- 	| sh64 | sh64le \
+@@ -265,6 +266,7 @@ case $basic_machine in
  	| sparc | sparc64 | sparc86x | sparclet | sparclite | sparcv9 | sparcv9b \
  	| strongarm \
--	| tahoe | thumb | tic80 | tron \
-+	| tahoe | dvp | thumb | tic80 | tron \
+ 	| tahoe | thumb | tic4x | tic80 | tron \
++	| dvp \
  	| v850 | v850e \
  	| we32k \
  	| x86 | xscale | xstormy16 | xtensa \
-@@ -322,6 +323,7 @@ case $basic_machine in
+@@ -326,6 +328,7 @@ case $basic_machine in
  	| mipsisa64sb1-* | mipsisa64sb1el-* \
  	| mipsisa64sr71k-* | mipsisa64sr71kel-* \
  	| mipstx39-* | mipstx39el-* \
@@ -757,7 +758,7 @@ index fe4f1edf3c..118a5a30dc 100755
  	| msp430-* \
  	| none-* | np1-* | nv1-* | ns16k-* | ns32k-* \
  	| orion-* \
-@@ -635,6 +637,24 @@ case $basic_machine in
+@@ -649,6 +652,24 @@ case $basic_machine in
  		basic_machine=m68k-atari
  		os=-mint
  		;;
@@ -782,42 +783,42 @@ index fe4f1edf3c..118a5a30dc 100755
  	mips3*-*)
  		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`
  		;;
-@@ -1131,7 +1151,7 @@ case $os in
+@@ -1163,7 +1184,7 @@ case $os in
  	      | -storm-chaos* | -tops10* | -tenex* | -tops20* | -its* \
  	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
  	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
--	      | -powermax* | -dnix*)
-+	      | -powermax* | -dnix* | -irx*)
+-	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly*)
++	      | -powermax* | -dnix* | -irx* | -nx6 | -nx7 | -sei* | -dragonfly*)
  	# Remember, each alternative MUST END IN *, to match a version number.
  		;;
  	-qnx*)
 diff --git a/configure b/configure
-index b4082420b2..3ddae6ba1f 100755
+index d11c49b15d..c71817ed5c 100755
 --- a/configure
 +++ b/configure
-@@ -1116,6 +1116,9 @@ case "${target}" in
+@@ -1240,6 +1240,9 @@ case "${target}" in
    d30v-*-*)
-     noconfigdirs="$noconfigdirs ${libgcj}"
+     noconfigdirs="$noconfigdirs ${libgcj} gdb"
      ;;
 +  dvp-*-*)
 +    noconfigdirs="$noconfigdirs ld"
 +    ;;
    fr30-*-elf*)
-     noconfigdirs="$noconfigdirs ${libgcj}"
+     noconfigdirs="$noconfigdirs ${libgcj} gdb"
      ;;
 diff --git a/configure.in b/configure.in
-index bfa3b2fe99..3011454533 100644
+index 6c0c465cd7..959016aba0 100644
 --- a/configure.in
 +++ b/configure.in
-@@ -456,6 +456,9 @@ case "${target}" in
+@@ -473,6 +473,9 @@ case "${target}" in
    d30v-*-*)
-     noconfigdirs="$noconfigdirs ${libgcj}"
+     noconfigdirs="$noconfigdirs ${libgcj} gdb"
      ;;
 +  dvp-*-*)
 +    noconfigdirs="$noconfigdirs ld"
 +    ;;
    fr30-*-elf*)
-     noconfigdirs="$noconfigdirs ${libgcj}"
+     noconfigdirs="$noconfigdirs ${libgcj} gdb"
      ;;
 diff --git a/gas/config/tc-dvp.c b/gas/config/tc-dvp.c
 new file mode 100644
@@ -4378,46 +4379,26 @@ index 0000000000..dca3e694f1
 +  { ".vudata",	SHT_PROGBITS,	SHF_ALLOC + SHF_WRITE		}, \
 +  { ".vutext",	SHT_PROGBITS,	SHF_ALLOC + SHF_EXECINSTR	},
 diff --git a/gas/config/tc-mips.c b/gas/config/tc-mips.c
-index 7e4c8438ca..6019a6b385 100644
+index 7b6cee85df..d287956ec6 100644
 --- a/gas/config/tc-mips.c
 +++ b/gas/config/tc-mips.c
-@@ -177,6 +177,10 @@ struct mips_set_options
-      is passed but can changed if the assembler code uses .set mipsN.  */
-   int gp32;
-   int fp32;
-+  /* r5900 support with mips1/mips2. */
-+  /* save mips_arch value on .set push */
-+  int march;
-+
- };
- 
- /* True if -mgp32 was passed.  */
-@@ -191,7 +195,7 @@ static int file_mips_fp32 = -1;
- 
- static struct mips_set_options mips_opts =
- {
--  ISA_UNKNOWN, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0
-+  ISA_UNKNOWN, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, CPU_UNKNOWN
- };
- 
- /* These variables are filled in with the masks of registers used.
-@@ -323,6 +327,7 @@ static int mips_32bitmode = 0;
- #define hilo_interlocks (mips_arch == CPU_R4010                       \
-                          || mips_arch == CPU_VR5500                   \
-                          || mips_arch == CPU_SB1                      \
-+			 || mips_arch == CPU_R5900		      \
-                          )
- 
- /* Whether the processor uses hardware interlocks to protect reads
-@@ -331,6 +336,7 @@ static int mips_32bitmode = 0;
+@@ -343,6 +343,7 @@ static int mips_32bitmode = 0;
+    || mips_opts.isa == ISA_MIPS64                     \
+    || mips_opts.isa == ISA_MIPS64R2                   \
+    || mips_opts.arch == CPU_R4010                     \
++   || mips_opts.arch == CPU_R5900                     \
+    || mips_opts.arch == CPU_R10000                    \
+    || mips_opts.arch == CPU_R12000                    \
+    || mips_opts.arch == CPU_RM7000                    \
+@@ -359,6 +360,7 @@ static int mips_32bitmode = 0;
    (mips_opts.isa != ISA_MIPS1  \
-    || mips_arch == CPU_VR5400  \
-    || mips_arch == CPU_VR5500  \
-+   || mips_arch == CPU_R5900   \
-    || mips_arch == CPU_R3900)
+    || mips_opts.arch == CPU_VR5400  \
+    || mips_opts.arch == CPU_VR5500  \
++   || mips_opts.arch == CPU_R5900  \
+    || mips_opts.arch == CPU_R3900)
  
- /* As with other "interlocks" this is used by hardware that has FP
-@@ -377,6 +383,12 @@ static int mips_any_noreorder;
+ /* Whether the processor uses hardware interlocks to avoid delays
+@@ -418,6 +420,12 @@ static int mips_any_noreorder;
     an mfhi/mflo instruction is read in the next two instructions.  */
  static int mips_7000_hilo_fix;
  
@@ -4430,29 +4411,29 @@ index 7e4c8438ca..6019a6b385 100644
  /* The size of the small data section.  */
  static unsigned int g_switch_value = 8;
  /* Whether the -G option was used.  */
-@@ -952,6 +964,10 @@ static int validate_mips_insn
-   PARAMS ((const struct mips_opcode *));
- static void show
-   PARAMS ((FILE *, const char *, int *, int *));
+@@ -914,6 +922,10 @@ static void s_mips_loc (int);
+ static bfd_boolean pic_need_relax (symbolS *, asection *);
+ static int relaxed_branch_length (fragS *, asection *, int);
+ static int validate_mips_insn (const struct mips_opcode *);
 +static int is_jump
 +  PARAMS ((unsigned long));
 +static int check_short_loop
 +  PARAMS ((int, fixS *));
- #ifdef OBJ_ELF
- static int mips_need_elf_addend_fixup
-   PARAMS ((fixS *));
-@@ -1184,6 +1200,10 @@ md_begin ()
+ 
+ /* Table and functions used to map between CPU/ISA names, and
+    ISA levels, and CPU numbers.  */
+@@ -1134,6 +1146,10 @@ md_begin (void)
    int i = 0;
    int broken = 0;
  
 +  /* set default value, if not specified */
 +  if (mips_warn_short_loop == -1)
-+    mips_warn_short_loop = (mips_arch == CPU_R5900);
++    mips_warn_short_loop = (mips_opts.arch == CPU_R5900);
 +
-   if (! bfd_set_arch_mach (stdoutput, bfd_arch_mips, mips_arch))
+   if (! bfd_set_arch_mach (stdoutput, bfd_arch_mips, file_mips_arch))
      as_warn (_("Could not set architecture and machine"));
  
-@@ -2142,6 +2162,10 @@ append_insn (place, ip, address_expr, reloc_type)
+@@ -2142,6 +2158,10 @@ append_insn (struct mips_cl_insn *ip, expressionS *address_expr,
  		 | ((address_expr->X_add_number & 0x3fffc) >> 2));
  	      break;
  
@@ -4463,21 +4444,22 @@ index 7e4c8438ca..6019a6b385 100644
  	    case BFD_RELOC_16_PCREL_S2:
  	      goto need_reloc;
  
-@@ -3005,6 +3029,7 @@ macro_build (place, counter, ep, name, fmt, va_alist)
+@@ -3007,7 +3027,7 @@ macro_build (expressionS *ep, const char *name, const char *fmt, ...)
    			       (mips_opts.isa
  	      		        | (file_ase_mips16 ? INSN_MIPS16 : 0)),
- 			       mips_arch)
-+          && (mips_arch != CPU_R5900 || (insn.insn_mo->pinfo & FP_D) == 0)
- 	  && (mips_arch != CPU_R4650 || (insn.insn_mo->pinfo & FP_D) == 0))
+ 			       mips_opts.arch)
+-	  && (mips_opts.arch != CPU_R4650 || (insn.insn_mo->pinfo & FP_D) == 0))
++	  && (mips_opts.arch != CPU_R4650 || mips_opts.arch != CPU_R5900 || (insn.insn_mo->pinfo & FP_D) == 0))
  	break;
  
-@@ -3544,6 +3569,24 @@ check_absolute_expr (ip, ex)
+       ++insn.insn_mo;
+@@ -3552,6 +3572,24 @@ check_absolute_expr (struct mips_cl_insn *ip, expressionS *ex)
             ? 1                          \
             : 0)
  
 +#define UPGRADE_R5900_ISA                               \
 +  {                                                     \
-+    if ((mips_arch == CPU_R5900) && (mips_opts.isa != ISA_MIPS3))       \
++    if ((mips_opts.arch == CPU_R5900) && (mips_opts.isa != ISA_MIPS3))       \
 +      {                                                 \
 +        save_isa = mips_opts.isa;                       \
 +        mips_opts.isa = ISA_MIPS3;                      \
@@ -4494,9 +4476,9 @@ index 7e4c8438ca..6019a6b385 100644
 +  }
 +
  /*			load_register()
-  *  This routine generates the least number of instructions neccessary to load
+  *  This routine generates the least number of instructions necessary to load
   *  an absolute expression value into a register.
-@@ -3557,6 +3600,7 @@ load_register (counter, reg, ep, dbl)
+@@ -3561,6 +3599,7 @@ load_register (int reg, expressionS *ep, int dbl)
  {
    int freg;
    expressionS hi32, lo32;
@@ -4504,11 +4486,11 @@ index 7e4c8438ca..6019a6b385 100644
  
    if (ep->X_op != O_big)
      {
-@@ -3609,12 +3653,21 @@ load_register (counter, reg, ep, dbl)
+@@ -3606,11 +3645,20 @@ load_register (int reg, expressionS *ep, int dbl)
  
    if (HAVE_32BIT_GPRS)
      {
-+      if (mips_arch == CPU_R5900)
++      if (mips_opts.arch == CPU_R5900)
 +        {
 +          as_warn (_("Number larger than 32 bits (r5900, but isa:%d)"),
 +                   mips_opts.isa);
@@ -4517,8 +4499,7 @@ index 7e4c8438ca..6019a6b385 100644
 +        {
        as_bad (_("Number (0x%lx) larger than 32 bits"),
  	      (unsigned long) ep->X_add_number);
-       macro_build ((char *) NULL, counter, ep, "addiu", "t,r,j", reg, 0,
- 		   (int) BFD_RELOC_LO16);
+       macro_build (ep, "addiu", "t,r,j", reg, 0, BFD_RELOC_LO16);
        return;
      }
 +    }
@@ -4526,42 +4507,42 @@ index 7e4c8438ca..6019a6b385 100644
  
    if (ep->X_op != O_big)
      {
-@@ -3651,6 +3704,7 @@ load_register (counter, reg, ep, dbl)
+@@ -3646,6 +3694,7 @@ load_register (int reg, expressionS *ep, int dbl)
+ 	  if ((lo32.X_add_number & 0xffff8000) == 0xffff8000)
  	    {
- 	      macro_build ((char *) NULL, counter, &lo32, "addiu", "t,r,j",
- 			   reg, 0, (int) BFD_RELOC_LO16);
+ 	      macro_build (&lo32, "addiu", "t,r,j", reg, 0, BFD_RELOC_LO16);
 +	      RESTORE_R5900_ISA;
  	      return;
  	    }
  	  if (lo32.X_add_number & 0x80000000)
-@@ -3660,6 +3714,7 @@ load_register (counter, reg, ep, dbl)
+@@ -3653,6 +3702,7 @@ load_register (int reg, expressionS *ep, int dbl)
+ 	      macro_build (&lo32, "lui", "t,u", reg, BFD_RELOC_HI16);
  	      if (lo32.X_add_number & 0xffff)
- 		macro_build ((char *) NULL, counter, &lo32, "ori", "t,r,i",
- 			     reg, reg, (int) BFD_RELOC_LO16);
+ 		macro_build (&lo32, "ori", "t,r,i", reg, reg, BFD_RELOC_LO16);
 +	      RESTORE_R5900_ISA;
  	      return;
  	    }
  	}
-@@ -3700,6 +3755,7 @@ load_register (counter, reg, ep, dbl)
- 			   (shift >= 32) ? "dsll32" : "dsll",
- 			   "d,w,<", reg, reg,
- 			   (shift >= 32) ? shift - 32 : shift);
+@@ -3689,6 +3739,7 @@ load_register (int reg, expressionS *ep, int dbl)
+ 	      macro_build (&tmp, "ori", "t,r,i", reg, 0, BFD_RELOC_LO16);
+ 	      macro_build (NULL, (shift >= 32) ? "dsll32" : "dsll", "d,w,<",
+ 			   reg, reg, (shift >= 32) ? shift - 32 : shift);
 +	      RESTORE_R5900_ISA;
  	      return;
  	    }
  	  ++shift;
-@@ -3760,6 +3816,7 @@ load_register (counter, reg, ep, dbl)
- 			   (shift >= 32) ? "dsrl32" : "dsrl",
- 			   "d,w,<", reg, reg,
- 			   (shift >= 32) ? shift - 32 : shift);
+@@ -3744,6 +3795,7 @@ load_register (int reg, expressionS *ep, int dbl)
+ 		}
+ 	      macro_build (NULL, (shift >= 32) ? "dsrl32" : "dsrl", "d,w,<",
+ 			   reg, reg, (shift >= 32) ? shift - 32 : shift);
 +	      RESTORE_R5900_ISA;
  	      return;
  	    }
  	}
-@@ -3790,11 +3847,13 @@ load_register (counter, reg, ep, dbl)
- 		       (int) BFD_RELOC_HI16);
- 	  macro_build ((char *) NULL, counter, (expressionS *) NULL,
- 		       "dsrl32", "d,w,<", reg, reg, 0);
+@@ -3771,11 +3823,13 @@ load_register (int reg, expressionS *ep, int dbl)
+ 	{
+ 	  macro_build (&lo32, "lui", "t,u", reg, BFD_RELOC_HI16);
+ 	  macro_build (NULL, "dsrl32", "d,w,<", reg, reg, 0);
 +          RESTORE_R5900_ISA;
  	  return;
  	}
@@ -4569,156 +4550,158 @@ index 7e4c8438ca..6019a6b385 100644
        if (freg != 0)
  	{
 +	  UPGRADE_R5900_ISA;
- 	  macro_build ((char *) NULL, counter, (expressionS *) NULL, "dsll",
- 		       "d,w,<", reg, freg, 16);
+ 	  macro_build (NULL, "dsll", "d,w,<", reg, freg, 16);
  	  freg = reg;
-@@ -3810,6 +3869,7 @@ load_register (counter, reg, ep, dbl)
+ 	}
+@@ -3787,6 +3841,7 @@ load_register (int reg, expressionS *ep, int dbl)
+     }
    if ((lo32.X_add_number & 0xffff) != 0)
-     macro_build ((char *) NULL, counter, &lo32, "ori", "t,r,i", reg, freg,
- 		 (int) BFD_RELOC_LO16);
+     macro_build (&lo32, "ori", "t,r,i", reg, freg, BFD_RELOC_LO16);
 +  RESTORE_R5900_ISA;
  }
  
  /* Load an address into a register.  */
-@@ -4683,6 +4743,9 @@ macro (ip)
+@@ -4680,6 +4735,8 @@ macro (struct mips_cl_insn *ip)
+ 	  as_warn (_("Divide by zero."));
  	  if (mips_trap)
- 	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "teq",
- 			 "s,t,q", 0, 0, 7);
-+	  else if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+			 "B", 7);
+ 	    macro_build (NULL, "teq", "s,t,q", 0, 0, 7);
++	  else if (mips_opts.arch == CPU_R5900)
++	    macro_build (NULL, "break", "B", 7);
  	  else
- 	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 			 "c", 7);
-@@ -4705,6 +4768,10 @@ macro (ip)
- 	  macro_build ((char *) NULL, &icnt, &expr1, "bne", "s,t,p", treg, 0);
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL,
- 		       dbl ? "ddiv" : "div", "z,s,t", sreg, treg);
-+          if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+		         "B", 7);
+ 	    macro_build (NULL, "break", "c", 7);
+ 	  return;
+@@ -4698,7 +4755,10 @@ macro (struct mips_cl_insn *ip)
+ 	  expr1.X_add_number = 8;
+ 	  macro_build (&expr1, "bne", "s,t,p", treg, 0);
+ 	  macro_build (NULL, dbl ? "ddiv" : "div", "z,s,t", sreg, treg);
+-	  macro_build (NULL, "break", "c", 7);
++      if (mips_opts.arch == CPU_R5900)
++	    macro_build (NULL, "break", "B", 7);
 +	  else
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 		       "c", 7);
++	    macro_build (NULL, "break", "c", 7);
  	}
-@@ -4747,6 +4814,10 @@ macro (ip)
+       expr1.X_add_number = -1;
+       load_register (AT, &expr1, dbl);
+@@ -4732,7 +4792,10 @@ macro (struct mips_cl_insn *ip)
  	     that later insns are available for delay slot filling.  */
  	  --mips_opts.noreorder;
  
-+	  if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+		         "B", 6);
+-	  macro_build (NULL, "break", "c", 6);
++	  if (mips_opts.arch == CPU_R5900)
++	      macro_build (NULL, "break", "B", 6);
 +	  else
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 		       "c", 6);
++	      macro_build (NULL, "break", "c", 6);
  	}
-@@ -4795,6 +4866,9 @@ macro (ip)
+       macro_build (NULL, s, "d", dreg);
+       break;
+@@ -4778,6 +4841,8 @@ macro (struct mips_cl_insn *ip)
+ 	  as_warn (_("Divide by zero."));
  	  if (mips_trap)
- 	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "teq",
- 			 "s,t,q", 0, 0, 7);
-+	  else if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+			 "B", 7);
+ 	    macro_build (NULL, "teq", "s,t,q", 0, 0, 7);
++	  else if (mips_opts.arch == CPU_R5900)
++	    macro_build (NULL, "break", "B", 7);
  	  else
- 	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 			 "c", 7);
-@@ -4867,6 +4941,10 @@ macro (ip)
+ 	    macro_build (NULL, "break", "c", 7);
+ 	  return;
+@@ -4844,7 +4909,10 @@ macro (struct mips_cl_insn *ip)
  	  /* We want to close the noreorder block as soon as possible, so
  	     that later insns are available for delay slot filling.  */
  	  --mips_opts.noreorder;
-+	  if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+		         "B", 7);
+-	  macro_build (NULL, "break", "c", 7);
++	  if (mips_opts.arch == CPU_R5900)
++	    macro_build (NULL, "break", "B", 7);
 +	  else
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 		       "c", 7);
++	    macro_build (NULL, "break", "c", 7);
  	}
-@@ -6732,7 +6810,7 @@ macro (ip)
+       macro_build (NULL, s2, "d", dreg);
+       return;
+@@ -6438,7 +6506,7 @@ macro (struct mips_cl_insn *ip)
        s = segment_name (S_GET_SEGMENT (offset_expr.X_add_symbol));
        if (strcmp (s, ".lit8") == 0)
  	{
 -	  if (mips_opts.isa != ISA_MIPS1)
-+	  if (mips_opts.isa != ISA_MIPS1 && mips_arch != CPU_R5900)
++	  if (mips_opts.isa != ISA_MIPS1 && mips_opts.arch != CPU_R5900)
  	    {
- 	      macro_build ((char *) NULL, &icnt, &offset_expr, "ldc1",
- 			   "T,o(b)", treg, (int) BFD_RELOC_MIPS_LITERAL,
-@@ -6757,7 +6835,7 @@ macro (ip)
- 	      macro_build_lui (NULL, &icnt, &offset_expr, AT);
+ 	      macro_build (&offset_expr, "ldc1", "T,o(b)", treg,
+ 			   BFD_RELOC_MIPS_LITERAL, mips_gp_register);
+@@ -6460,7 +6528,7 @@ macro (struct mips_cl_insn *ip)
+ 	      macro_build_lui (&offset_expr, AT);
  	    }
  
 -	  if (mips_opts.isa != ISA_MIPS1)
-+	  if (mips_opts.isa != ISA_MIPS1 && mips_arch != CPU_R5900)
++	  if (mips_opts.isa != ISA_MIPS1 && mips_opts.arch != CPU_R5900)
  	    {
- 	      macro_build ((char *) NULL, &icnt, &offset_expr, "ldc1",
- 			   "T,o(b)", treg, (int) BFD_RELOC_LO16, AT);
-@@ -6784,7 +6862,7 @@ macro (ip)
+ 	      macro_build (&offset_expr, "ldc1", "T,o(b)",
+ 			   treg, BFD_RELOC_LO16, AT);
+@@ -6481,7 +6549,7 @@ macro (struct mips_cl_insn *ip)
  	 to adjust when loading from memory.  */
        r = BFD_RELOC_LO16;
      dob:
 -      assert (mips_opts.isa == ISA_MIPS1);
-+      assert (mips_opts.isa == ISA_MIPS1 || mips_arch == CPU_R5900);
-       macro_build ((char *) NULL, &icnt, &offset_expr, "lwc1", "T,o(b)",
- 		   target_big_endian ? treg + 1 : treg,
- 		   (int) r, breg);
-@@ -6823,7 +6901,7 @@ macro (ip)
++      assert (mips_opts.isa == ISA_MIPS1 || mips_opts.arch == CPU_R5900);
+       macro_build (&offset_expr, "lwc1", "T,o(b)",
+ 		   target_big_endian ? treg + 1 : treg, r, breg);
+       /* FIXME: A possible overflow which I don't know how to deal
+@@ -6513,7 +6581,7 @@ macro (struct mips_cl_insn *ip)
  	}
        /* Itbl support may require additional care here.  */
        coproc = 1;
 -      if (mips_opts.isa != ISA_MIPS1)
-+      if (mips_opts.isa != ISA_MIPS1 && mips_arch != CPU_R5900)
++      if (mips_opts.isa != ISA_MIPS1 && mips_opts.arch != CPU_R5900)
  	{
  	  s = "ldc1";
  	  goto ld;
-@@ -6840,7 +6918,7 @@ macro (ip)
+@@ -6530,7 +6598,7 @@ macro (struct mips_cl_insn *ip)
  	  return;
  	}
  
 -      if (mips_opts.isa != ISA_MIPS1)
-+      if (mips_opts.isa != ISA_MIPS1 && mips_arch != CPU_R5900)
++      if (mips_opts.isa != ISA_MIPS1 && mips_opts.arch != CPU_R5900)
  	{
  	  s = "sdc1";
  	  goto st;
-@@ -7386,6 +7464,10 @@ macro2 (ip)
- 		       AT);
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "nop", "",
- 		       0);
-+	  if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+		         "B", 6);
+@@ -6986,6 +7054,10 @@ macro2 (struct mips_cl_insn *ip)
+ 	  macro_build (&expr1, "beq", "s,t,p", dreg, AT);
+ 	  macro_build (NULL, "nop", "", 0);
+ 	  macro_build (NULL, "break", "c", 6);
++	  if (mips_opts.arch == CPU_R5900)
++	    macro_build (NULL, "break", "B", 6);
 +	  else
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 		       "c", 6);
++	    macro_build (NULL, "break", "c", 6);
  	}
-@@ -7424,6 +7506,10 @@ macro2 (ip)
- 	  macro_build ((char *) NULL, &icnt, &expr1, "beq", "s,t,p", AT, 0);
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "nop", "",
- 		       0);
-+	  if (mips_arch == CPU_R5900)
-+	    macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
-+		         "B", 6);
+       --mips_opts.noreorder;
+       macro_build (NULL, "mflo", "d", dreg);
+@@ -7017,7 +7089,10 @@ macro2 (struct mips_cl_insn *ip)
+ 	  expr1.X_add_number = 8;
+ 	  macro_build (&expr1, "beq", "s,t,p", AT, 0);
+ 	  macro_build (NULL, "nop", "", 0);
+-	  macro_build (NULL, "break", "c", 6);
++	  if (mips_opts.arch == CPU_R5900)
++	    macro_build (NULL, "break", "B", 6);
 +	  else
- 	  macro_build ((char *) NULL, &icnt, (expressionS *) NULL, "break",
- 		       "c", 6);
++	    macro_build (NULL, "break", "c", 6);
  	}
-@@ -7661,7 +7747,7 @@ macro2 (ip)
+       --mips_opts.noreorder;
+       break;
+@@ -7209,7 +7284,7 @@ macro2 (struct mips_cl_insn *ip)
  	  as_bad (_("opcode not supported on this processor"));
  	  return;
  	}
 -      assert (mips_opts.isa == ISA_MIPS1);
-+      assert (mips_opts.isa == ISA_MIPS1 || mips_arch == CPU_R5900);
++      assert (mips_opts.isa == ISA_MIPS1 || mips_opts.arch == CPU_R5900);
        /* Even on a big endian machine $fn comes before $fn+1.  We have
  	 to adjust when storing to memory.  */
-       macro_build ((char *) NULL, &icnt, &offset_expr, "swc1", "T,o(b)",
-@@ -7970,7 +8056,7 @@ macro2 (ip)
+       macro_build (&offset_expr, "swc1", "T,o(b)",
+@@ -7477,7 +7552,7 @@ macro2 (struct mips_cl_insn *ip)
  
      case M_TRUNCWS:
      case M_TRUNCWD:
 -      assert (mips_opts.isa == ISA_MIPS1);
-+      assert (mips_opts.isa == ISA_MIPS1 || mips_arch == CPU_R5900);
++      assert (mips_opts.isa == ISA_MIPS1 || mips_opts.arch == CPU_R5900);
        sreg = (ip->insn_opcode >> 11) & 0x1f;	/* floating reg */
        dreg = (ip->insn_opcode >> 06) & 0x1f;	/* floating reg */
  
-@@ -8509,7 +8595,7 @@ validate_mips_insn (opc)
+@@ -7956,7 +8031,7 @@ validate_mips_insn (const struct mips_opcode *opc)
        case ',': break;
        case '(': break;
        case ')': break;
@@ -4727,7 +4710,7 @@ index 7e4c8438ca..6019a6b385 100644
      	switch (c = *p++)
  	  {
  	  case 'A': USE_BITS (OP_MASK_SHAMT,	OP_SH_SHAMT);	break;
-@@ -8574,6 +8660,35 @@ validate_mips_insn (opc)
+@@ -8026,6 +8101,35 @@ validate_mips_insn (const struct mips_opcode *opc)
        case 'P': USE_BITS (OP_MASK_PERFREG,	OP_SH_PERFREG);	break;
        case 'U': USE_BITS (OP_MASK_RD,           OP_SH_RD);
  	        USE_BITS (OP_MASK_RT,           OP_SH_RT);	break;
@@ -4763,7 +4746,7 @@ index 7e4c8438ca..6019a6b385 100644
        case 'e': USE_BITS (OP_MASK_VECBYTE,	OP_SH_VECBYTE);	break;
        case '%': USE_BITS (OP_MASK_VECALIGN,	OP_SH_VECALIGN); break;
        case '[': break;
-@@ -8614,6 +8729,7 @@ mips_ip (str, ip)
+@@ -8064,6 +8168,7 @@ mips_ip (char *str, struct mips_cl_insn *ip)
    unsigned int limlo, limhi;
    char *s_reset;
    char save_c = 0;
@@ -4771,7 +4754,7 @@ index 7e4c8438ca..6019a6b385 100644
  
    insn_error = NULL;
  
-@@ -8663,6 +8779,7 @@ mips_ip (str, ip)
+@@ -8113,6 +8218,7 @@ mips_ip (char *str, struct mips_cl_insn *ip)
  	  insn_error = "unrecognized opcode";
  	  return;
  	}
@@ -4779,17 +4762,16 @@ index 7e4c8438ca..6019a6b385 100644
      }
  
    argsStart = s;
-@@ -8684,7 +8801,8 @@ mips_ip (str, ip)
+@@ -8134,7 +8240,7 @@ mips_ip (char *str, struct mips_cl_insn *ip)
  
        if (insn->pinfo != INSN_MACRO)
  	{
--	  if (mips_arch == CPU_R4650 && (insn->pinfo & FP_D) != 0)
-+	  if ((mips_arch == CPU_R4650 || mips_arch == CPU_R5900) &&
-+              (insn->pinfo & FP_D) != 0)
+-	  if (mips_opts.arch == CPU_R4650 && (insn->pinfo & FP_D) != 0)
++	  if ((mips_opts.arch == CPU_R4650 || mips_opts.arch == CPU_R5900) && (insn->pinfo & FP_D) != 0)
  	    ok = FALSE;
  	}
  
-@@ -8773,11 +8891,13 @@ mips_ip (str, ip)
+@@ -8218,11 +8324,13 @@ mips_ip (char *str, struct mips_cl_insn *ip)
  	    case ')':		/* these must match exactly */
  	    case '[':
  	    case ']':
@@ -4804,7 +4786,7 @@ index 7e4c8438ca..6019a6b385 100644
  	      switch (*++args)
  		{
  		case 'A':		/* ins/ext position, becomes LSB.  */
-@@ -8894,6 +9014,173 @@ mips_ip (str, ip)
+@@ -8371,6 +8479,173 @@ do_msbd:
  	      s = expr_end;
  	      continue;
  
@@ -4978,12 +4960,12 @@ index 7e4c8438ca..6019a6b385 100644
  	    case 'k':		/* cache code */
  	    case 'h':		/* prefx code */
  	      my_getExpression (&imm_expr, s);
-@@ -9007,6 +9294,14 @@ mips_ip (str, ip)
+@@ -8484,6 +8759,14 @@ do_msbd:
  	      s_reset = s;
  	      if (s[0] == '$')
  		{
 +                  /* Allow "$viNN" as coprocessor register name */
-+                  if (mips_arch == CPU_R5900
++                  if (mips_opts.arch == CPU_R5900
 +                      && *args == 'G'
 +                      && s[1] == 'v'
 +                      && s[2] == 'i')
@@ -4993,7 +4975,7 @@ index 7e4c8438ca..6019a6b385 100644
  
  		  if (ISDIGIT (s[1]))
  		    {
-@@ -9026,47 +9321,56 @@ mips_ip (str, ip)
+@@ -8503,47 +8786,56 @@ do_msbd:
  		    goto notreg;
  		  else
  		    {
@@ -5091,7 +5073,7 @@ index 7e4c8438ca..6019a6b385 100644
  			{
  			  char *p, *n;
  			  unsigned long r;
-@@ -9090,7 +9394,7 @@ mips_ip (str, ip)
+@@ -8567,7 +8859,7 @@ do_msbd:
  			  else
  			    goto notreg;
  			}
@@ -5100,7 +5082,7 @@ index 7e4c8438ca..6019a6b385 100644
  			goto notreg;
  		    }
  		  if (regno == AT
-@@ -9223,6 +9527,14 @@ mips_ip (str, ip)
+@@ -8700,6 +8992,14 @@ do_msbd:
  	    case 'R':		/* floating point source register */
  	    case 'V':
  	    case 'W':
@@ -5115,7 +5097,7 @@ index 7e4c8438ca..6019a6b385 100644
  	      s_reset = s;
  	      /* Accept $fN for FP and MDMX register numbers, and in
                   addition accept $vN for MDMX register numbers.  */
-@@ -9245,6 +9557,7 @@ mips_ip (str, ip)
+@@ -8722,6 +9022,7 @@ do_msbd:
  
  		  if ((regno & 1) != 0
  		      && HAVE_32BIT_FPRS
@@ -5123,7 +5105,7 @@ index 7e4c8438ca..6019a6b385 100644
  		      && ! (strcmp (str, "mtc1") == 0
  			    || strcmp (str, "mfc1") == 0
  			    || strcmp (str, "lwc1") == 0
-@@ -9323,6 +9636,94 @@ mips_ip (str, ip)
+@@ -8800,6 +9101,94 @@ do_msbd:
  		  lastregno = regno;
  		  continue;
  		}
@@ -5218,29 +5200,30 @@ index 7e4c8438ca..6019a6b385 100644
  
  	      switch (*args++)
  		{
-@@ -10805,8 +11206,20 @@ struct option md_longopts[] =
+@@ -10291,8 +10680,21 @@ struct option md_longopts[] =
    {"no-relax-branch", no_argument, NULL, OPTION_NO_RELAX_BRANCH},
- #define OPTION_MIPS32R2 (OPTION_MD_BASE + 41)
-   {"mips32r2", no_argument, NULL, OPTION_MIPS32R2},
-+#define OPTION_M5900 (OPTION_MD_BASE + 42)
+ 
+   /* ELF-specific options.  */
++#define OPTION_M5900_BASE (OPTION_NO_RELAX_BRANCH + 13)
++#define OPTION_M5900 (OPTION_M5900_BASE + 0)
 +  {"m5900", no_argument, NULL, OPTION_M5900},
-+#define OPTION_NO_M5900 (OPTION_MD_BASE + 43)
++#define OPTION_NO_M5900 (OPTION_M5900_BASE + 1)
 +  {"no-m5900", no_argument, NULL, OPTION_NO_M5900},
-+#define OPTION_WARN_SHORT_LOOP (OPTION_MD_BASE + 44)
++#define OPTION_WARN_SHORT_LOOP (OPTION_M5900_BASE + 2)
 +  {"mwarn-short-loop", no_argument, NULL, OPTION_WARN_SHORT_LOOP},
-+#define OPTION_NO_WARN_SHORT_LOOP (OPTION_MD_BASE + 45)
++#define OPTION_NO_WARN_SHORT_LOOP (OPTION_M5900_BASE + 3)
 +  {"mno-warn-short-loop", no_argument, NULL, OPTION_NO_WARN_SHORT_LOOP},
-+#define OPTION_SINGLE_FLOAT (OPTION_MD_BASE + 46)
++#define OPTION_SINGLE_FLOAT (OPTION_M5900_BASE + 4)
 +  {"msingle-float", no_argument, NULL,  OPTION_SINGLE_FLOAT},
-+#define OPTION_NO_SINGLE_FLOAT (OPTION_MD_BASE + 47)
++#define OPTION_NO_SINGLE_FLOAT (OPTION_M5900_BASE + 5)
 +  {"no-msingle-float", no_argument, NULL, OPTION_NO_SINGLE_FLOAT},
  #ifdef OBJ_ELF
--#define OPTION_ELF_BASE    (OPTION_MD_BASE + 42)
-+#define OPTION_ELF_BASE    (OPTION_MD_BASE + 48)
+-#define OPTION_ELF_BASE    (OPTION_MISC_BASE + 13)
++#define OPTION_ELF_BASE    (OPTION_M5900_BASE + 6)
  #define OPTION_CALL_SHARED (OPTION_ELF_BASE + 0)
    {"KPIC",        no_argument, NULL, OPTION_CALL_SHARED},
    {"call_shared", no_argument, NULL, OPTION_CALL_SHARED},
-@@ -10898,8 +11311,9 @@ md_parse_option (c, arg)
+@@ -10382,8 +10784,9 @@ md_parse_option (int c, char *arg)
  	mips_debug = atoi (arg);
        /* When the MIPS assembler sees -g or -g2, it does not do
           optimizations which limit full symbolic debugging.  We take
@@ -5252,7 +5235,7 @@ index 7e4c8438ca..6019a6b385 100644
  	mips_optimize = 1;
        break;
  
-@@ -10975,6 +11389,14 @@ md_parse_option (c, arg)
+@@ -10463,6 +10866,14 @@ md_parse_option (int c, char *arg)
      case OPTION_NO_M3900:
        break;
  
@@ -5267,7 +5250,7 @@ index 7e4c8438ca..6019a6b385 100644
      case OPTION_MDMX:
        mips_opts.ase_mdmx = 1;
        break;
-@@ -11027,6 +11449,22 @@ md_parse_option (c, arg)
+@@ -10515,6 +10926,22 @@ md_parse_option (int c, char *arg)
        mips_relax_branch = 0;
        break;
  
@@ -5290,26 +5273,18 @@ index 7e4c8438ca..6019a6b385 100644
  #ifdef OBJ_ELF
        /* When generating ELF code, we permit -KPIC and -call_shared to
  	 select SVR4_PIC, and -non_shared to select no PIC.  This is
-@@ -11216,6 +11654,7 @@ mips_set_tune (info)
- void
- mips_after_parse_args ()
- {
-+
-   /* GP relative stuff not working for PE */
-   if (strncmp (TARGET_OS, "pe", 2) == 0
-       && g_switch_value != 0)
-@@ -11333,6 +11772,10 @@ mips_after_parse_args ()
+@@ -10833,6 +11260,10 @@ mips_after_parse_args (void)
  	mips_flag_mdebug = 1;
        else
  #endif /* OBJ_MAYBE_ECOFF */
 +      /* We default to .mdebug (ECOFF-style debugging) for R5900 and IRX.  */
-+      if (mips_arch == CPU_R5900 || strcmp (TARGET_OS, "irx") == 0)
++      if (mips_opts.arch == CPU_R5900 || strcmp (TARGET_OS, "irx") == 0)
 +        mips_flag_mdebug = 1;
 +      else
  	mips_flag_mdebug = 0;
      }
  }
-@@ -11580,6 +12023,129 @@ mips_validate_fix (fixP, seg)
+@@ -11080,6 +11511,129 @@ mips_validate_fix (struct fix *fixP, asection *seg)
    return 1;
  }
  
@@ -5436,10 +5411,10 @@ index 7e4c8438ca..6019a6b385 100644
 +        return 1;
 +}
 +
- #ifdef OBJ_ELF
- static int
- mips_need_elf_addend_fixup (fixP)
-@@ -11785,6 +12351,7 @@ md_apply_fix3 (fixP, valP, seg)
+ /* Apply a fixup to the object file.  */
+ 
+ void
+@@ -11147,6 +11701,7 @@ md_apply_fix3 (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
      case BFD_RELOC_MIPS_CALL_HI16:
      case BFD_RELOC_MIPS_CALL_LO16:
      case BFD_RELOC_MIPS16_GPREL:
@@ -5447,56 +5422,46 @@ index 7e4c8438ca..6019a6b385 100644
        if (fixP->fx_pcrel)
  	as_bad_where (fixP->fx_file, fixP->fx_line,
  		      _("Invalid PC relative reloc"));
-@@ -11933,6 +12500,17 @@ md_apply_fix3 (fixP, valP, seg)
+@@ -11270,6 +11825,17 @@ md_apply_fix3 (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
        else
  	insn = (buf[3] << 24) | (buf[2] << 16) | (buf[1] << 8) | buf[0];
  
-+      /* check short loop */
-+      if (mips_warn_short_loop
-+         && ( ( insn & 0xffff0000) != 0x10000000        /* beq $0,$0 */
-+            && (insn & 0xffff0000) != 0x04010000        /* bgez $0 */
-+            && (insn & 0xffff0000) != 0x04110000 )      /* bgezal $0 */
-+         ) {
-+          if ( check_short_loop( -(value+1),fixP) )
-+            as_warn_where (fixP->fx_file, fixP->fx_line,
-+                      _("Loop length is too short for r5900."));
-+      }
++	/* check short loop */
++	if (mips_warn_short_loop
++		&& ( ( insn & 0xffff0000) != 0x10000000        /* beq $0,$0 */
++		&& (insn & 0xffff0000) != 0x04010000        /* bgez $0 */
++		&& (insn & 0xffff0000) != 0x04110000 )      /* bgezal $0 */
++		) {
++		if ( check_short_loop( -(*valP +1),fixP) )
++		as_warn_where (fixP->fx_file, fixP->fx_line,
++					_("Loop length is too short for r5900."));
++	}
 +
-       if (value + 0x8000 <= 0xffff)
- 	insn |= value & 0xffff;
-       else
-@@ -12539,6 +13117,12 @@ s_mipsset (x)
+       if (*valP + 0x20000 <= 0x3ffff)
+ 	{
+ 	  insn |= (*valP >> 2) & 0xffff;
+@@ -11885,6 +12451,12 @@ s_mipsset (int x ATTRIBUTE_UNUSED)
      mips_opts.ase_mdmx = 1;
    else if (strcmp (name, "nomdmx") == 0)
      mips_opts.ase_mdmx = 0;
 +  /* r5900 support with mips1/mips2 */
 +  else if (strcmp (name, "r5900") == 0)
 +    {
-+            mips_arch = CPU_R5900;
++            mips_opts.arch = CPU_R5900;
 +            mips_opts.isa = ISA_MIPS3;
 +    }
-   else if (strncmp (name, "mips", 4) == 0)
+   else if (strncmp (name, "mips", 4) == 0 || strncmp (name, "arch=", 5) == 0)
      {
        int reset = 0;
-@@ -12607,6 +13191,8 @@ s_mipsset (x)
+@@ -11975,6 +12547,7 @@ s_mipsset (int x ATTRIBUTE_UNUSED)
  
        s = (struct mips_option_stack *) xmalloc (sizeof *s);
        s->next = mips_opts_stack;
 +      /* r5900 support with mips1/mips2 */
-+      mips_opts.march = mips_arch;
        s->options = mips_opts;
        mips_opts_stack = s;
      }
-@@ -12635,6 +13221,8 @@ s_mipsset (x)
- 
- 	  mips_opts = s->options;
- 	  mips_opts_stack = s->next;
-+         /* r5900 support with mips1/mips2 */
-+          mips_arch = mips_opts.march;
- 	  free (s);
- 	}
-     }
-@@ -14909,6 +15497,7 @@ static const struct mips_cpu_info mips_cpu_info_table[] =
+@@ -14137,6 +14710,7 @@ static const struct mips_cpu_info mips_cpu_info_table[] =
    { "r4600",          0,      ISA_MIPS3,      CPU_R4600 },
    { "orion",          0,      ISA_MIPS3,      CPU_R4600 },
    { "r4650",          0,      ISA_MIPS3,      CPU_R4650 },
@@ -5504,7 +5469,7 @@ index 7e4c8438ca..6019a6b385 100644
  
    /* MIPS IV */
    { "r8000",          0,      ISA_MIPS4,      CPU_R8000 },
-@@ -15134,6 +15723,7 @@ MIPS options:\n\
+@@ -14367,6 +14941,7 @@ MIPS options:\n\
    show (stream, "4010", &column, &first);
    show (stream, "4100", &column, &first);
    show (stream, "4650", &column, &first);
@@ -5513,10 +5478,10 @@ index 7e4c8438ca..6019a6b385 100644
  
    fprintf (stream, _("\
 diff --git a/gas/configure b/gas/configure
-index 0354251274..98a5bb7466 100755
+index e66abca67b..3eaec15885 100755
 --- a/gas/configure
 +++ b/gas/configure
-@@ -2338,6 +2338,7 @@ for this_target in $target $canon_targets ; do
+@@ -4172,6 +4172,7 @@ for this_target in $target $canon_targets ; do
        m5200)		cpu_type=m68k ;;
        m8*)		cpu_type=m88k ;;
        mips*el)		cpu_type=mips endian=little ;;
@@ -5524,8 +5489,8 @@ index 0354251274..98a5bb7466 100755
        mips*)		cpu_type=mips endian=big ;;
        or32*)		cpu_type=or32 endian=big ;;
        pjl*)		cpu_type=pj endian=little ;;
-@@ -2423,6 +2424,8 @@ for this_target in $target $canon_targets ; do
-       fr30-*-*)				fmt=elf ;;
+@@ -4263,6 +4264,8 @@ for this_target in $target $canon_targets ; do
+       frv-*-*linux*)			fmt=elf em=linux;;
        frv-*-*)				fmt=elf ;;
  
 +      dvp-*-*)				fmt=elf bfd_gas=yes install_tooldir= ;;
@@ -5533,7 +5498,7 @@ index 0354251274..98a5bb7466 100755
        hppa-*-linux*)	case ${cpu} in
  			    hppa*64*)	fmt=elf em=hppalinux64;;
  			    hppa*)	fmt=elf em=linux;;
-@@ -2577,6 +2580,7 @@ EOF
+@@ -4426,6 +4429,7 @@ echo "$as_me: error: Unknown vendor for mips-bsd configuration." >&2;}
        mips-*-irix6*)			fmt=elf em=irix ;;
        mips-*-irix5*)			fmt=elf em=irix ;;
        mips-*-irix*)			fmt=ecoff em=irix ;;
@@ -5541,19 +5506,19 @@ index 0354251274..98a5bb7466 100755
        mips-*-lnews*)			fmt=ecoff em=lnews ;;
        mips-*-riscos*)			fmt=ecoff ;;
        mips*-*-linux*)			fmt=elf em=tmips ;;
-@@ -2586,6 +2590,7 @@ EOF
+@@ -4434,6 +4438,7 @@ echo "$as_me: error: Unknown vendor for mips-bsd configuration." >&2;}
+       mips-*-elf* | mips-*-rtems*)	fmt=elf ;;
        mips-*-netbsd*)			fmt=elf ;;
        mips-*-openbsd*)			fmt=elf ;;
-       mips-*-vxworks*)			fmt=elf ;;
 +      mips*-*-irx*)			fmt=elf endian=little em=mipsirx ;;
  
        mmix-*-*)				fmt=elf ;;
        mn10200-*-*)			fmt=elf ;;
 diff --git a/gas/configure.in b/gas/configure.in
-index 7b7b40e05f..b2444125a7 100644
+index f7d0acbcae..d33705227d 100644
 --- a/gas/configure.in
 +++ b/gas/configure.in
-@@ -132,6 +132,7 @@ changequote([,])dnl
+@@ -142,6 +142,7 @@ changequote([,])dnl
        m5200)		cpu_type=m68k ;;
        m8*)		cpu_type=m88k ;;
        mips*el)		cpu_type=mips endian=little ;;
@@ -5561,8 +5526,8 @@ index 7b7b40e05f..b2444125a7 100644
        mips*)		cpu_type=mips endian=big ;;
        or32*)		cpu_type=or32 endian=big ;;
        pjl*)		cpu_type=pj endian=little ;;
-@@ -217,6 +218,8 @@ changequote([,])dnl
-       fr30-*-*)				fmt=elf ;;
+@@ -233,6 +234,8 @@ changequote([,])dnl
+       frv-*-*linux*)			fmt=elf em=linux;;
        frv-*-*)				fmt=elf ;;
  
 +      dvp-*-*)				fmt=elf bfd_gas=yes install_tooldir= ;;
@@ -5570,19 +5535,19 @@ index 7b7b40e05f..b2444125a7 100644
        hppa-*-linux*)	case ${cpu} in
  			    hppa*64*)	fmt=elf em=hppalinux64;;
  			    hppa*)	fmt=elf em=linux;;
-@@ -376,6 +379,7 @@ changequote([,])dnl
+@@ -395,6 +398,7 @@ changequote([,])dnl
+       mips-*-elf* | mips-*-rtems*)	fmt=elf ;;
        mips-*-netbsd*)			fmt=elf ;;
        mips-*-openbsd*)			fmt=elf ;;
-       mips-*-vxworks*)			fmt=elf ;;
 +      mips-*-irx*)			fmt=elf endian=little em=mipsirx ;;
  
        mmix-*-*)				fmt=elf ;;
        mn10200-*-*)			fmt=elf ;;
 diff --git a/gas/symbols.c b/gas/symbols.c
-index 59658dff0d..e3525792fb 100644
+index 761a020851..edb1801e75 100644
 --- a/gas/symbols.c
 +++ b/gas/symbols.c
-@@ -1027,6 +1027,7 @@ resolve_symbol_value (symp)
+@@ -1009,6 +1009,7 @@ resolve_symbol_value (symbolS *symp)
  	      goto exit_dont_set_value;
  	    }
  	  else if (finalize_syms && final_seg == expr_section
@@ -5591,20 +5556,20 @@ index 59658dff0d..e3525792fb 100644
  	    {
  	      /* If the symbol is an expression symbol, do similarly
 diff --git a/include/dis-asm.h b/include/dis-asm.h
-index 392cbf9b46..425ea8ede7 100644
+index 3670c51898..6fb96b9a93 100644
 --- a/include/dis-asm.h
 +++ b/include/dis-asm.h
-@@ -242,6 +242,8 @@ extern int print_insn_sh64		PARAMS ((bfd_vma, disassemble_info *));
- extern int print_insn_sh64x_media	PARAMS ((bfd_vma, disassemble_info *));
- extern int print_insn_frv		PARAMS ((bfd_vma, disassemble_info *));
- extern int print_insn_iq2000            PARAMS ((bfd_vma, disassemble_info *));
+@@ -247,6 +247,8 @@ extern int print_insn_sh64		(bfd_vma, disassemble_info *);
+ extern int print_insn_sh64x_media	(bfd_vma, disassemble_info *);
+ extern int print_insn_frv		(bfd_vma, disassemble_info *);
+ extern int print_insn_iq2000		(bfd_vma, disassemble_info *);
 +extern int print_insn_dvp		PARAMS ((bfd_vma, disassemble_info*));
 +extern int dvp_insn_p			PARAMS ((disassemble_info*));
  
- extern disassembler_ftype arc_get_disassembler PARAMS ((void *));
- extern disassembler_ftype cris_get_disassembler PARAMS ((bfd *));
+ extern disassembler_ftype arc_get_disassembler (void *);
+ extern disassembler_ftype cris_get_disassembler (bfd *);
 diff --git a/include/elf/common.h b/include/elf/common.h
-index ca79342860..1d60022723 100644
+index bf233f61df..4a82e2d4ab 100644
 --- a/include/elf/common.h
 +++ b/include/elf/common.h
 @@ -92,6 +92,7 @@
@@ -5622,9 +5587,9 @@ index ca79342860..1d60022723 100644
 +#define PT_MIPS_IRXHDR	0x70000080	/* Sony's ugly IRX-ELF extension */
  
  #define PT_GNU_EH_FRAME	(PT_LOOS + 0x474e550)
- 
+ #define PT_GNU_STACK	(PT_LOOS + 0x474e551)
 diff --git a/include/elf/mips.h b/include/elf/mips.h
-index 44f7cb9292..286e637eec 100644
+index ce43158123..33b84ab04e 100644
 --- a/include/elf/mips.h
 +++ b/include/elf/mips.h
 @@ -76,6 +76,13 @@ START_RELOC_NUMBERS (elf_mips_reloc_type)
@@ -5641,7 +5606,7 @@ index 44f7cb9292..286e637eec 100644
    /* These are GNU extensions to handle embedded-pic.  */
    RELOC_NUMBER (R_MIPS_PC32, 248)
    RELOC_NUMBER (R_MIPS_PC64, 249)
-@@ -186,6 +193,7 @@ END_RELOC_NUMBERS (R_MIPS_maxext)
+@@ -189,6 +196,7 @@ END_RELOC_NUMBERS (R_MIPS_maxext)
  #define E_MIPS_MACH_SB1         0x008a0000
  #define E_MIPS_MACH_5400	0x00910000
  #define E_MIPS_MACH_5500	0x00980000
@@ -5649,7 +5614,7 @@ index 44f7cb9292..286e637eec 100644
  
  /* Processor specific section indices.  These sections do not actually
     exist.  Symbols with a st_shndx field corresponding to one of these
-@@ -333,6 +341,17 @@ END_RELOC_NUMBERS (R_MIPS_maxext)
+@@ -336,6 +344,17 @@ END_RELOC_NUMBERS (R_MIPS_maxext)
  /* Runtime procedure descriptor table exception information (ucode) ??? */
  #define SHT_MIPS_PDR_EXCEPTION	0x70000029
  
@@ -5667,18 +5632,18 @@ index 44f7cb9292..286e637eec 100644
  
  /* A section of type SHT_MIPS_LIBLIST contains an array of the
     following structure.  The sh_link field is the section index of the
-@@ -499,6 +518,10 @@ extern void bfd_mips_elf32_swap_reginfo_out
+@@ -501,6 +520,10 @@ extern void bfd_mips_elf32_swap_reginfo_out
+ 
  /* .MIPS.options section.  */
  #define PT_MIPS_OPTIONS		0x70000002
- 
++
 +/* IRX header */
 +/* #define PT_MIPS_IRXHDR		0x70000080 let's define it in common.h...*/
 +
-+
+ 
  /* Processor specific dynamic array tags.  */
  
- /* 32 bit version number for runtime linker interface.  */
-@@ -690,6 +713,16 @@ extern void bfd_mips_elf32_swap_reginfo_out
+@@ -693,6 +716,16 @@ extern void bfd_mips_elf32_swap_reginfo_out
  #define STO_HIDDEN		STV_HIDDEN
  #define STO_PROTECTED		STV_PROTECTED
  
@@ -5695,9 +5660,9 @@ index 44f7cb9292..286e637eec 100644
  /* This value is used for a mips16 .text symbol.  */
  #define STO_MIPS16		0xf0
  
-@@ -930,6 +963,31 @@ extern void bfd_mips_elf64_swap_reginfo_in
+@@ -933,6 +966,31 @@ extern void bfd_mips_elf64_swap_reginfo_in
  extern void bfd_mips_elf64_swap_reginfo_out
-   PARAMS ((bfd *, const Elf64_Internal_RegInfo *, Elf64_External_RegInfo *));
+   (bfd *, const Elf64_Internal_RegInfo *, Elf64_External_RegInfo *);
  
 +/* The vu overlay table is an array of this.  */
 +
@@ -6188,7 +6153,7 @@ index 0000000000..63f065d9c3
 +void dvp_opcode_init_parse PARAMS ((void));
 +void dvp_opcode_init_print PARAMS ((void));
 diff --git a/include/opcode/mips.h b/include/opcode/mips.h
-index 476c8e3112..2044b9ae5e 100644
+index 5c3ddfcd7b..71560ecd09 100644
 --- a/include/opcode/mips.h
 +++ b/include/opcode/mips.h
 @@ -164,6 +164,24 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  *
@@ -6216,31 +6181,9 @@ index 476c8e3112..2044b9ae5e 100644
  /* Values in the 'VSEL' field.  */
  #define MDMX_FMTSEL_IMM_QH	0x1d
  #define MDMX_FMTSEL_IMM_OB	0x1e
-@@ -233,13 +251,13 @@ struct mips_opcode
-    "x" accept and ignore register name
-    "z" must be zero register
-    "K" 5 bit Hardware Register (rdhwr instruction) (OP_*_RD)
--   "+A" 5 bit ins/ext position, which becomes LSB (OP_*_SHAMT).
-+   "*A" 5 bit ins/ext position, which becomes LSB (OP_*_SHAMT).
- 	Enforces: 0 <= pos < 32.
--   "+B" 5 bit ins size, which becomes MSB (OP_*_INSMSB).
--	Requires that "+A" occur first to set position.
-+   "*B" 5 bit ins size, which becomes MSB (OP_*_INSMSB).
-+	Requires that "*A" occur first to set position.
- 	Enforces: 0 < (pos+size) <= 32.
--   "+C" 5 bit ext size, which becomes MSBD (OP_*_EXTMSBD).
--	Requires that "+A" occur first to set position.
-+   "*C" 5 bit ext size, which becomes MSBD (OP_*_EXTMSBD).
-+	Requires that "*A" occur first to set position.
- 	Enforces: 0 < (pos+size) <= 32.
- 
-    Floating point instructions:
-@@ -260,8 +278,27 @@ struct mips_opcode
-    "e" 5 bit vector register byte specifier (OP_*_VECBYTE)
-    "%" 3 bit immediate vr5400 vector alignment operand (OP_*_VECALIGN)
+@@ -275,6 +293,25 @@ struct mips_opcode
     see also "k" above
--   "+D" Combined destination register ("G") and sel ("H") for CP0 ops,
-+   "*D" Combined destination register ("G") and sel ("H") for CP0 ops,
+    "+D" Combined destination register ("G") and sel ("H") for CP0 ops,
  	for pretty-printing in disassembly only.
 +   "0" vu0 immediate for viaddi (OP_*_VADDI) 
 +   "1" vu0 fp reg position 1 (OP_*_VUTREG) 
@@ -6264,27 +6207,7 @@ index 476c8e3112..2044b9ae5e 100644
  
     Macro instructions:
     "A" General 32 bit expression
-@@ -283,14 +320,15 @@ struct mips_opcode
-    "()" parens surrounding optional value
-    ","  separates operands
-    "[]" brackets around index for vector-op scalar operand specifier (vr5400)
--   "+"  Start of extension sequence.
-+   "+-" auto inc/dec decorators
-+   "*"  Start of extension sequence.
- 
-    Characters used so far, for quick reference when adding more:
--   "%[]<>(),+"
-+   "%[]<>(),*!#&+-0123456789;^_="
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
--   "abcdefhijklopqrstuvwxz"
-+   "abcdefghijkl  opqrstuvwx z"
- 
--   Extension character sequences used so far ("+" followed by the
-+   Extension character sequences used so far ("*" followed by the
-    following), for quick reference when adding more:
-    "ABCD"
- */
-@@ -418,6 +456,8 @@ struct mips_opcode
+@@ -433,6 +470,8 @@ struct mips_opcode
  #define INSN_5400		  0x01000000
  /* NEC VR5500 instruction.  */
  #define INSN_5500		  0x02000000
@@ -6293,15 +6216,15 @@ index 476c8e3112..2044b9ae5e 100644
  
  /* MIPS ISA defines, use instead of hardcoding ISA level.  */
  
-@@ -450,6 +490,7 @@ struct mips_opcode
+@@ -467,6 +506,7 @@ struct mips_opcode
  #define CPU_R5000	5000
  #define CPU_VR5400	5400
  #define CPU_VR5500	5500
 +#define CPU_R5900       5900
  #define CPU_R6000	6000
+ #define CPU_RM7000	7000
  #define CPU_R8000	8000
- #define CPU_R10000	10000
-@@ -479,6 +520,7 @@ struct mips_opcode
+@@ -499,6 +539,7 @@ struct mips_opcode
       || (cpu == CPU_VR4120 && ((insn)->membership & INSN_4120) != 0)	\
       || (cpu == CPU_VR5400 && ((insn)->membership & INSN_5400) != 0)	\
       || (cpu == CPU_VR5500 && ((insn)->membership & INSN_5500) != 0)	\
@@ -6328,10 +6251,10 @@ index 86707fc1d2..e77066a3fd 100644
  /* Forward declaration for a node in the tree.  */
  typedef struct splay_tree_node_s *splay_tree_node;
 diff --git a/ld/Makefile.am b/ld/Makefile.am
-index 1cee856f48..5fca4294e7 100644
+index a2f1ac1afa..b438b064c8 100644
 --- a/ld/Makefile.am
 +++ b/ld/Makefile.am
-@@ -154,6 +154,7 @@ ALL_EMULATIONS = \
+@@ -149,6 +149,7 @@ ALL_EMULATIONS = \
  	eelf32_i860.o \
  	eelf32_sparc.o \
  	eelf32b4300.o \
@@ -6339,7 +6262,7 @@ index 1cee856f48..5fca4294e7 100644
  	eelf32bmip.o \
  	eelf32bmipn32.o \
  	eelf32btsmip.o \
-@@ -249,6 +250,7 @@ ALL_EMULATIONS = \
+@@ -253,6 +254,7 @@ ALL_EMULATIONS = \
  	emipsbsd.o \
  	emipsidt.o \
  	emipsidtl.o \
@@ -6347,17 +6270,17 @@ index 1cee856f48..5fca4294e7 100644
  	emipslit.o \
  	emipslnews.o \
  	emipspe.o \
-@@ -662,6 +664,9 @@ eelf32l4300.c: $(srcdir)/emulparams/elf32l4300.sh \
-   $(srcdir)/emulparams/elf32b4300.sh $(srcdir)/emulparams/elf32bmip.sh \
+@@ -673,6 +675,9 @@ eelf32l4300.c: $(srcdir)/emulparams/elf32l4300.sh \
+   $(srcdir)/emultempl/mipself.em \
    $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
  	${GENSCRIPTS} elf32l4300 "$(tdir_elf32l4300)"
 +eelf32l5900.c: $(srcdir)/emulparams/elf32l5900.sh
 +  $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 +	${GENSCRIPTS} elf32l5900 "$(tdir_elf32l5900)"
  eelf32lmip.c: $(srcdir)/emulparams/elf32lmip.sh \
-   $(srcdir)/emulparams/elf32bmip.sh \
+   $(srcdir)/emulparams/elf32bmip.sh $(srcdir)/emultempl/mipself.em \
    $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
-@@ -1002,6 +1007,9 @@ emipsidt.c: $(srcdir)/emulparams/mipsidt.sh \
+@@ -1037,6 +1042,9 @@ emipsidt.c: $(srcdir)/emulparams/mipsidt.sh \
  emipsidtl.c: $(srcdir)/emulparams/mipsidtl.sh \
    $(srcdir)/emultempl/mipsecoff.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
  	${GENSCRIPTS} mipsidtl "$(tdir_mipsidtl)"
@@ -6368,10 +6291,10 @@ index 1cee856f48..5fca4294e7 100644
    $(srcdir)/emultempl/generic.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
  	${GENSCRIPTS} mipslit "$(tdir_mipslit)"
 diff --git a/ld/Makefile.in b/ld/Makefile.in
-index cb2e2a41a1..22803b6759 100644
+index 976d5db826..e3c595980d 100644
 --- a/ld/Makefile.in
 +++ b/ld/Makefile.in
-@@ -283,6 +283,7 @@ ALL_EMULATIONS = \
+@@ -278,6 +278,7 @@ ALL_EMULATIONS = \
  	eelf32iq2000.o \
  	eelf32iq10.o \
  	eelf32l4300.o \
@@ -6379,7 +6302,7 @@ index cb2e2a41a1..22803b6759 100644
  	eelf32lmip.o \
  	eelf32lppc.o \
  	eelf32lppcnto.o \
-@@ -363,6 +364,7 @@ ALL_EMULATIONS = \
+@@ -367,6 +368,7 @@ ALL_EMULATIONS = \
  	emipsbsd.o \
  	emipsidt.o \
  	emipsidtl.o \
@@ -6387,17 +6310,17 @@ index cb2e2a41a1..22803b6759 100644
  	emipslit.o \
  	emipslnews.o \
  	emipspe.o \
-@@ -1388,6 +1390,9 @@ eelf32l4300.c: $(srcdir)/emulparams/elf32l4300.sh \
-   $(srcdir)/emulparams/elf32b4300.sh $(srcdir)/emulparams/elf32bmip.sh \
+@@ -1399,6 +1401,9 @@ eelf32l4300.c: $(srcdir)/emulparams/elf32l4300.sh \
+   $(srcdir)/emultempl/mipself.em \
    $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
  	${GENSCRIPTS} elf32l4300 "$(tdir_elf32l4300)"
 +eelf32l5900.c: $(srcdir)/emulparams/elf32l5900.sh \
 +  $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 +	${GENSCRIPTS} elf32l5900 "$(tdir_elf32l5900)"
  eelf32lmip.c: $(srcdir)/emulparams/elf32lmip.sh \
-   $(srcdir)/emulparams/elf32bmip.sh \
+   $(srcdir)/emulparams/elf32bmip.sh $(srcdir)/emultempl/mipself.em \
    $(srcdir)/emultempl/elf32.em $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
-@@ -1728,6 +1733,9 @@ emipsidt.c: $(srcdir)/emulparams/mipsidt.sh \
+@@ -1763,6 +1768,9 @@ emipsidt.c: $(srcdir)/emulparams/mipsidt.sh \
  emipsidtl.c: $(srcdir)/emulparams/mipsidtl.sh \
    $(srcdir)/emultempl/mipsecoff.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
  	${GENSCRIPTS} mipsidtl "$(tdir_mipsidtl)"
@@ -6408,10 +6331,10 @@ index cb2e2a41a1..22803b6759 100644
    $(srcdir)/emultempl/generic.em $(srcdir)/scripttempl/mips.sc ${GEN_DEPENDS}
  	${GENSCRIPTS} mipslit "$(tdir_mipslit)"
 diff --git a/ld/configure.tgt b/ld/configure.tgt
-index 1e45cfcda5..15a97d1b79 100644
+index 9b2929180c..95bb468487 100644
 --- a/ld/configure.tgt
 +++ b/ld/configure.tgt
-@@ -404,8 +404,15 @@ mips*vr4100el-*-elf*)	targ_emul=elf32l4300 ;;
+@@ -421,8 +421,15 @@ mips*vr4100el-*-elf*)	targ_emul=elf32l4300 ;;
  mips*vr4100-*-elf*)	targ_emul=elf32b4300 ;;
  mips*vr5000el-*-elf*)	targ_emul=elf32l4300 ;;
  mips*vr5000-*-elf*)	targ_emul=elf32b4300 ;;
@@ -6453,7 +6376,7 @@ index 0000000000..cfa08c5456
 +
 diff --git a/ld/emultempl/irx.em b/ld/emultempl/irx.em
 new file mode 100644
-index 0000000000..c0679b2e1d
+index 0000000000..6ffc50ca5f
 --- /dev/null
 +++ b/ld/emultempl/irx.em
 @@ -0,0 +1,560 @@
@@ -6543,10 +6466,10 @@ index 0000000000..c0679b2e1d
 +static void
 +gld${EMULATION_NAME}_before_parse (void)
 +{
-+  ldfile_set_output_arch ("`echo ${ARCH}`");
++  ldfile_set_output_arch ("`echo ${ARCH}`",bfd_mach_mips3000);
 +
 +  /* Only setup IRX headers for executable files.  */
-+  if (link_info.relocateable)
++  if (link_info.relocatable)
 +    {
 +      building_irx = FALSE;
 +      return;
@@ -6950,11 +6873,11 @@ index 0000000000..c0679b2e1d
 +{			     
 +  *isfile = 0;
 +
-+  if (link_info.relocateable && config.build_constructors)
++  if (link_info.relocatable && config.build_constructors)
 +    return
 +EOF
 +sed $sc ldscripts/${EMULATION_NAME}.xu                 >> e${EMULATION_NAME}.c
-+echo '  ; else if (link_info.relocateable) return'     >> e${EMULATION_NAME}.c
++echo '  ; else if (link_info.relocatable) return'     >> e${EMULATION_NAME}.c
 +sed $sc ldscripts/${EMULATION_NAME}.xr                 >> e${EMULATION_NAME}.c
 +echo '  ; else if (!config.text_read_only) return'     >> e${EMULATION_NAME}.c
 +sed $sc ldscripts/${EMULATION_NAME}.xbn                >> e${EMULATION_NAME}.c
@@ -6971,9 +6894,9 @@ index 0000000000..c0679b2e1d
 +{			     
 +  *isfile = 1;
 +
-+  if (link_info.relocateable && config.build_constructors)
++  if (link_info.relocatable && config.build_constructors)
 +    return "ldscripts/${EMULATION_NAME}.xu";
-+  else if (link_info.relocateable)
++  else if (link_info.relocatable)
 +    return "ldscripts/${EMULATION_NAME}.xr";
 +  else if (!config.text_read_only)
 +    return "ldscripts/${EMULATION_NAME}.xbn";
@@ -7243,10 +7166,10 @@ index 0000000000..e776cf7cef
 +	PROVIDE(_stack_size = 128 * 1024);
 +}
 diff --git a/opcodes/configure b/opcodes/configure
-index bb079388ae..99691060b6 100755
+index 4a95a9a606..34223776ee 100755
 --- a/opcodes/configure
 +++ b/opcodes/configure
-@@ -4671,6 +4671,7 @@ if test x${all_targets} = xfalse ; then
+@@ -4693,6 +4693,7 @@ if test x${all_targets} = xfalse ; then
          bfd_tic4x_arch)         ta="$ta tic4x-dis.lo" ;;
  	bfd_tic54x_arch)	ta="$ta tic54x-dis.lo tic54x-opc.lo" ;;
  	bfd_tic80_arch)		ta="$ta tic80-dis.lo tic80-opc.lo" ;;
@@ -7255,7 +7178,7 @@ index bb079388ae..99691060b6 100755
  	bfd_v850e_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
  	bfd_v850ea_arch)	ta="$ta v850-opc.lo v850-dis.lo" ;;
 diff --git a/opcodes/configure.in b/opcodes/configure.in
-index ea64c849a6..44c110870b 100644
+index 89199243a2..d48b9fad89 100644
 --- a/opcodes/configure.in
 +++ b/opcodes/configure.in
 @@ -234,6 +234,7 @@ if test x${all_targets} = xfalse ; then
@@ -7267,18 +7190,10 @@ index ea64c849a6..44c110870b 100644
  	bfd_v850e_arch)		ta="$ta v850-opc.lo v850-dis.lo" ;;
  	bfd_v850ea_arch)	ta="$ta v850-opc.lo v850-dis.lo" ;;
 diff --git a/opcodes/disassemble.c b/opcodes/disassemble.c
-index 1408f39b1c..d1980c1cb2 100644
+index d5b17be325..0ebfd521fa 100644
 --- a/opcodes/disassemble.c
 +++ b/opcodes/disassemble.c
-@@ -75,7 +75,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
- #define INCLUDE_SHMEDIA
- #endif
- 
--
- disassembler_ftype
- disassembler (abfd)
-      bfd *abfd;
-@@ -232,12 +231,16 @@ disassembler (abfd)
+@@ -235,12 +235,16 @@ disassembler (abfd)
        disassemble = print_insn_mcore;
        break;
  #endif
@@ -11206,7 +11121,7 @@ index 0000000000..5fc26b32ef
 +  return NULL;
 +}
 diff --git a/opcodes/mips-dis.c b/opcodes/mips-dis.c
-index 1ed436a0d0..02029c34b6 100644
+index 43fcb3ca79..f314cc1556 100644
 --- a/opcodes/mips-dis.c
 +++ b/opcodes/mips-dis.c
 @@ -345,6 +345,8 @@ const struct mips_arch_choice mips_arch_choices[] = {
@@ -11217,8 +11132,8 @@ index 1ed436a0d0..02029c34b6 100644
 +    mips_cp0_names_numeric, NULL, 0, mips_hwr_names_numeric },
    { "r6000",	1, bfd_mach_mips6000, CPU_R6000, ISA_MIPS2,
      mips_cp0_names_numeric, NULL, 0, mips_hwr_names_numeric },
-   { "r8000",	1, bfd_mach_mips8000, CPU_R8000, ISA_MIPS4,
-@@ -685,10 +687,12 @@ print_insn_args (d, l, pc, info)
+   { "rm7000",	1, bfd_mach_mips7000, CPU_RM7000, ISA_MIPS4,
+@@ -695,10 +697,12 @@ print_insn_args (d, l, pc, info)
  	case ')':
  	case '[':
  	case ']':
@@ -11232,7 +11147,7 @@ index 1ed436a0d0..02029c34b6 100644
  	  /* Extension character; switch for second char.  */
  	  d++;
  	  switch (*d)
-@@ -870,6 +874,140 @@ print_insn_args (d, l, pc, info)
+@@ -896,6 +900,140 @@ print_insn_args (d, l, pc, info)
  				 mips_fpr_names[(l >> OP_SH_FS) & OP_MASK_FS]);
  	  break;
  
@@ -11373,7 +11288,7 @@ index 1ed436a0d0..02029c34b6 100644
  	case 'T':
  	case 'W':
  	  (*info->fprintf_func) (info->stream, "%s",
-@@ -1107,8 +1245,12 @@ print_insn_mips (memaddr, word, info)
+@@ -1133,8 +1271,12 @@ print_insn_mips (memaddr, word, info)
  
  	      d = op->args;
  	      if (d != NULL && *d != '\0')
@@ -11387,7 +11302,7 @@ index 1ed436a0d0..02029c34b6 100644
  		  print_insn_args (d, word, memaddr, info);
  		}
  
-@@ -1138,6 +1280,19 @@ _print_insn_mips (memaddr, info, endianness)
+@@ -1164,6 +1306,19 @@ _print_insn_mips (memaddr, info, endianness)
    bfd_byte buffer[INSNLEN];
    int status;
  
@@ -11408,10 +11323,10 @@ index 1ed436a0d0..02029c34b6 100644
    parse_mips_dis_options (info->disassembler_options);
  
 diff --git a/opcodes/mips-opc.c b/opcodes/mips-opc.c
-index 228357a0c1..df7eb88d8a 100644
+index 9a80e53d43..d2dc39d9b1 100644
 --- a/opcodes/mips-opc.c
 +++ b/opcodes/mips-opc.c
-@@ -101,6 +101,7 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  *
+@@ -102,6 +102,7 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  *
  #define L1	INSN_4010
  #define V1	(INSN_4100 | INSN_4111 | INSN_4120)
  #define T3      INSN_3900
@@ -11419,7 +11334,7 @@ index 228357a0c1..df7eb88d8a 100644
  #define M1	INSN_10000
  #define SB1     INSN_SB1
  #define N411	INSN_4111
-@@ -110,12 +111,14 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  *
+@@ -111,12 +112,14 @@ Software Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  *
  #define N55	INSN_5500
  
  #define G1      (T3             \
@@ -11434,7 +11349,7 @@ index 228357a0c1..df7eb88d8a 100644
                   )
  
  /* The order of overloaded instructions matters.  Label arguments and
-@@ -169,6 +172,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -170,6 +173,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"add.qh",  "X,Y,Q",	0x7820000b, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	MX	},
  {"adda.ob", "Y,Q",	0x78000037, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX|SB1	},
  {"adda.qh", "Y,Q",	0x78200037, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX	},
@@ -11442,7 +11357,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"addi",    "t,r,j",	0x20000000, 0xfc000000,	WR_t|RD_s,		I1	},
  {"addiu",   "t,r,j",	0x24000000, 0xfc000000,	WR_t|RD_s,		I1	},
  {"addl.ob", "Y,Q",	0x78000437, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX|SB1	},
-@@ -273,7 +277,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -274,7 +278,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"bnel",    "s,t,p",	0x54000000, 0xfc000000,	CBL|RD_s|RD_t, 		I2|T3	},
  {"bnel",    "s,I,p",	0,    (int) M_BNEL_I,	INSN_MACRO,		I2|T3	},
  {"break",   "",		0x0000000d, 0xffffffff,	TRAP,			I1	},
@@ -11451,7 +11366,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"break",   "c",	0x0000000d, 0xfc00ffff,	TRAP,			I1	},
  {"break",   "c,q",	0x0000000d, 0xfc00003f,	TRAP,			I1	},
  {"c.f.d",   "S,T",	0x46200030, 0xffe007ff,	RD_S|RD_T|WR_CC|FP_D,	I1	},
-@@ -355,7 +359,13 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -356,7 +360,13 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"c.ngl.ps","M,S,T",	0x46c0003b, 0xffe000ff,	RD_S|RD_T|WR_CC|FP_D,	I5	},
  {"c.lt.d",  "S,T",	0x4620003c, 0xffe007ff,	RD_S|RD_T|WR_CC|FP_D,	I1	},
  {"c.lt.d",  "M,S,T",    0x4620003c, 0xffe000ff, RD_S|RD_T|WR_CC|FP_D,   I4|I32	},
@@ -11466,7 +11381,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"c.lt.s",  "M,S,T",    0x4600003c, 0xffe000ff, RD_S|RD_T|WR_CC|FP_S,   I4|I32	},
  {"c.lt.ob", "Y,Q",	0x78000004, 0xfc2007ff,	WR_CC|RD_S|RD_T|FP_D,	MX|SB1	},
  {"c.lt.ob", "S,T",	0x4ac00004, 0xffe007ff,	WR_CC|RD_S|RD_T,	N54	},
-@@ -372,7 +382,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -373,7 +383,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"c.nge.ps","M,S,T",	0x46c0003d, 0xffe000ff,	RD_S|RD_T|WR_CC|FP_D,	I5	},
  {"c.le.d",  "S,T",	0x4620003e, 0xffe007ff,	RD_S|RD_T|WR_CC|FP_D,	I1	},
  {"c.le.d",  "M,S,T",    0x4620003e, 0xffe000ff, RD_S|RD_T|WR_CC|FP_D,   I4|I32	},
@@ -11476,7 +11391,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"c.le.s",  "M,S,T",    0x4600003e, 0xffe000ff, RD_S|RD_T|WR_CC|FP_S,   I4|I32	},
  {"c.le.ob", "Y,Q",	0x78000005, 0xfc2007ff,	WR_CC|RD_S|RD_T|FP_D,	MX|SB1	},
  {"c.le.ob", "S,T",	0x4ac00005, 0xffe007ff,	WR_CC|RD_S|RD_T,	N54	},
-@@ -443,14 +454,24 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -444,14 +455,24 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"cfc0",    "t,G",	0x40400000, 0xffe007ff,	LCD|WR_t|RD_C0,		I1	},
  {"cfc1",    "t,G",	0x44400000, 0xffe007ff,	LCD|WR_t|RD_C1|FP_S,	I1	},
  {"cfc1",    "t,S",	0x44400000, 0xffe007ff,	LCD|WR_t|RD_C1|FP_S,	I1	},
@@ -11501,15 +11416,34 @@ index 228357a0c1..df7eb88d8a 100644
  {"ctc3",    "t,G",	0x4cc00000, 0xffe007ff,	COD|RD_t|WR_CC,		I1	},
  {"cvt.d.l", "D,S",	0x46a00021, 0xffff003f,	WR_D|RD_S|FP_D,		I3	},
  {"cvt.d.s", "D,S",	0x46000021, 0xffff003f,	WR_D|RD_S|FP_D|FP_S,	I1	},
-@@ -489,6 +510,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -484,8 +505,10 @@ const struct mips_opcode mips_builtin_opcodes[] =
+ {"deret",   "",         0x4200001f, 0xffffffff, 0, 			I32|G2	},
+ {"dext",    "t,r,I,+I",	0,    (int) M_DEXT,	INSN_MACRO,		I65	},
+ {"dext",    "t,r,+A,+C", 0x7c000003, 0xfc00003f, WR_t|RD_s,    		I65	},
++#if 0
+ {"dextm",   "t,r,+A,+G", 0x7c000001, 0xfc00003f, WR_t|RD_s,    		I65	},
+ {"dextu",   "t,r,+E,+H", 0x7c000002, 0xfc00003f, WR_t|RD_s,    		I65	},
++#endif
+ /* For ddiv, see the comments about div.  */
+ {"ddiv",    "z,s,t",    0x0000001e, 0xfc00ffff, RD_s|RD_t|WR_HILO,      I3      },
+ {"ddiv",    "d,v,t",	0,    (int) M_DDIV_3,	INSN_MACRO,		I3	},
+@@ -494,12 +517,15 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"ddivu",   "z,s,t",    0x0000001f, 0xfc00ffff, RD_s|RD_t|WR_HILO,      I3      },
  {"ddivu",   "d,v,t",	0,    (int) M_DDIVU_3,	INSN_MACRO,		I3	},
  {"ddivu",   "d,v,I",	0,    (int) M_DDIVU_3I,	INSN_MACRO,		I3	},
 +{"di",      "",         0x42000039, 0xffffffff, WR_C0,                  T5      },
  {"di",      "",		0x41606000, 0xffffffff,	WR_t|WR_C0,		I33	},
  {"di",      "t",	0x41606000, 0xffe0ffff,	WR_t|WR_C0,		I33	},
+ {"dins",    "t,r,I,+I",	0,    (int) M_DINS,	INSN_MACRO,		I65	},
+ {"dins",    "t,r,+A,+B", 0x7c000007, 0xfc00003f, WR_t|RD_s,    		I65	},
++#if 0
+ {"dinsm",   "t,r,+A,+F", 0x7c000005, 0xfc00003f, WR_t|RD_s,    		I65	},
+ {"dinsu",   "t,r,+E,+F", 0x7c000006, 0xfc00003f, WR_t|RD_s,    		I65	},
++#endif
  /* The MIPS assembler treats the div opcode with two operands as
-@@ -499,6 +521,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
+    though the first operand appeared twice (the first operand is both
+    a source and a destination).  To get the div machine instruction,
+@@ -508,6 +534,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"div",     "z,t",      0x0000001a, 0xffe0ffff, RD_s|RD_t|WR_HILO,      I1      },
  {"div",     "d,v,t",	0,    (int) M_DIV_3,	INSN_MACRO,		I1	},
  {"div",     "d,v,I",	0,    (int) M_DIV_3I,	INSN_MACRO,		I1	},
@@ -11518,16 +11452,16 @@ index 228357a0c1..df7eb88d8a 100644
  {"div.d",   "D,V,T",	0x46200003, 0xffe0003f,	WR_D|RD_S|RD_T|FP_D,	I1	},
  {"div.s",   "D,V,T",	0x46000003, 0xffe0003f,	WR_D|RD_S|RD_T|FP_S,	I1	},
  {"div.ps",  "D,V,T",	0x46c00003, 0xffe0003f,	WR_D|RD_S|RD_T|FP_D,	SB1	},
-@@ -507,6 +531,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -516,6 +544,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"divu",    "z,t",      0x0000001b, 0xffe0ffff, RD_s|RD_t|WR_HILO,      I1      },
  {"divu",    "d,v,t",	0,    (int) M_DIVU_3,	INSN_MACRO,		I1	},
  {"divu",    "d,v,I",	0,    (int) M_DIVU_3I,	INSN_MACRO,		I1	},
 +{"divu1",   "z,s,t",    0x7000001b, 0xfc00ffff, RD_s|RD_t|WR_HI|WR_LO,  T5      },
 +{"divu1",   "s,t",      0x7000001b, 0xffe0ffff, RD_s|RD_t|WR_HI|WR_LO,  T5      },
  {"dla",     "t,A(b)",	0,    (int) M_DLA_AB,	INSN_MACRO,		I3	},
+ {"dlca",    "t,A(b)",	0,    (int) M_DLCA_AB,	INSN_MACRO,		I3	},
  {"dli",     "t,j",      0x24000000, 0xffe00000, WR_t,			I3	}, /* addiu */
- {"dli",	    "t,i",	0x34000000, 0xffe00000, WR_t,			I3	}, /* ori */
-@@ -521,15 +547,22 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -531,15 +561,22 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"dmaccus", "d,s,t",	0x00000469, 0xfc0007ff,	RD_s|RD_t|WR_LO|WR_d,	N412	},
  {"dmadd16", "s,t",      0x00000029, 0xfc00ffff, RD_s|RD_t|MOD_LO,       N411    },
  {"dmfc0",   "t,G",	0x40200000, 0xffe007ff, LCD|WR_t|RD_C0,		I3	},
@@ -11552,7 +11486,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"dmfc2",   "t,G",      0x48200000, 0xffe007ff, LCD|WR_t|RD_C2, 	I3      },
  {"dmfc2",   "t,G,H",    0x48200000, 0xffe007f8, LCD|WR_t|RD_C2, 	I64     },
  {"dmtc2",   "t,G",      0x48a00000, 0xffe007ff, COD|RD_t|WR_C2|WR_CC,   I3      },
-@@ -581,10 +614,11 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -599,10 +636,11 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"dsub",    "d,v,I",	0,    (int) M_DSUB_I,	INSN_MACRO,		I3	},
  {"dsubu",   "d,v,t",	0x0000002f, 0xfc0007ff,	WR_d|RD_s|RD_t,		I3	},
  {"dsubu",   "d,v,I",	0,    (int) M_DSUBU_I,	INSN_MACRO,		I3	},
@@ -11566,7 +11500,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"floor.l.d", "D,S",	0x4620000b, 0xffff003f, WR_D|RD_S|FP_D,		I3	},
  {"floor.l.s", "D,S",	0x4600000b, 0xffff003f, WR_D|RD_S|FP_S,		I3	},
  {"floor.w.d", "D,S",	0x4620000f, 0xffff003f, WR_D|RD_S|FP_D,		I2	},
-@@ -593,7 +627,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -611,7 +649,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"flushd",  "",		0xbc020000, 0xffffffff, 0, 			L1	},
  {"flushid", "",		0xbc030000, 0xffffffff, 0, 			L1	},
  {"hibernate","",        0x42000023, 0xffffffff,	0, 			V1	},
@@ -11575,7 +11509,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"jr",      "s",	0x00000008, 0xfc1fffff,	UBD|RD_s,		I1	},
  {"jr.hb",   "s",	0x00000408, 0xfc1fffff,	UBD|RD_s,		I33	},
  {"j",       "s",	0x00000008, 0xfc1fffff,	UBD|RD_s,		I1	}, /* jr */
-@@ -631,8 +665,10 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -650,8 +688,10 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"ldc1",    "T,A(b)",	0,    (int) M_LDC1_AB,	INSN_MACRO,		I2	},
  {"ldc1",    "E,A(b)",	0,    (int) M_LDC1_AB,	INSN_MACRO,		I2	},
  {"l.d",     "T,o(b)",	0xd4000000, 0xfc000000, CLD|RD_b|WR_T|FP_D,	I2	}, /* ldc1 */
@@ -11588,7 +11522,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"ldc2",    "E,o(b)",	0xd8000000, 0xfc000000, CLD|RD_b|WR_CC,		I2	},
  {"ldc2",    "E,A(b)",	0,    (int) M_LDC2_AB,	INSN_MACRO,		I2	},
  {"ldc3",    "E,o(b)",	0xdc000000, 0xfc000000, CLD|RD_b|WR_CC,		I2	},
-@@ -657,6 +693,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -676,6 +716,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"lld",     "t,A(b)",	0,    (int) M_LLD_AB,	INSN_MACRO,		I3	},
  {"lui",     "t,u",	0x3c000000, 0xffe00000,	WR_t,			I1	},
  {"luxc1",   "D,t(b)",	0x4c000005, 0xfc00f83f, LDD|WR_D|RD_t|RD_b,	I5|N55	},
@@ -11596,7 +11530,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"lw",      "t,o(b)",	0x8c000000, 0xfc000000,	LDD|RD_b|WR_t,		I1	},
  {"lw",      "t,A(b)",	0,    (int) M_LW_AB,	INSN_MACRO,		I1	},
  {"lwc0",    "E,o(b)",	0xc0000000, 0xfc000000,	CLD|RD_b|WR_CC,		I1	},
-@@ -698,25 +735,35 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -717,25 +758,35 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"madu",    "s,t",      0x70000001, 0xfc00ffff, RD_s|RD_t|MOD_HILO,     P3      },
  {"madd.d",  "D,R,S,T",	0x4c000021, 0xfc00003f, RD_R|RD_S|RD_T|WR_D|FP_D,    I4	},
  {"madd.s",  "D,R,S,T",	0x4c000020, 0xfc00003f, RD_R|RD_S|RD_T|WR_D|FP_S,    I4	},
@@ -11634,7 +11568,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"mfc0",    "t,G,H",    0x40000000, 0xffe007f8, LCD|WR_t|RD_C0, 	I32     },
  {"mfc1",    "t,S",	0x44000000, 0xffe007ff,	LCD|WR_t|RD_S|FP_S,	I1	},
  {"mfc1",    "t,G",	0x44000000, 0xffe007ff,	LCD|WR_t|RD_S|FP_S,	I1	},
-@@ -727,14 +774,24 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -746,14 +797,24 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"mfhc2",   "t,i",	0x48600000, 0xffe00000,	LCD|WR_t|RD_C2,		I33	},
  {"mfc3",    "t,G",	0x4c000000, 0xffe007ff,	LCD|WR_t|RD_C3,		I1	},
  {"mfc3",    "t,G,H",    0x4c000000, 0xffe007f8, LCD|WR_t|RD_C3, 	I32     },
@@ -11659,7 +11593,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"mov.d",   "D,S",	0x46200006, 0xffff003f,	WR_D|RD_S|FP_D,		I1	},
  {"mov.s",   "D,S",	0x46000006, 0xffff003f,	WR_D|RD_S|FP_S,		I1	},
  {"mov.ps",  "D,S",	0x46c00006, 0xffff003f,	WR_D|RD_S|FP_D,		I5	},
-@@ -744,7 +801,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -763,7 +824,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"movf.l",  "X,Y,N",	0x46a00011, 0xffe3003f, WR_D|RD_S|RD_CC|FP_D,	MX|SB1	},
  {"movf.s",  "D,S,N",    0x46000011, 0xffe3003f, WR_D|RD_S|RD_CC|FP_S,   I4|I32	},
  {"movf.ps", "D,S,N",	0x46c00011, 0xffe3003f, WR_D|RD_S|RD_CC|FP_D,	I5	},
@@ -11668,7 +11602,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"ffc",     "d,v",	0x0000000b, 0xfc1f07ff,	WR_d|RD_s,		L1	},
  {"movn.d",  "D,S,t",    0x46200013, 0xffe0003f, WR_D|RD_S|RD_t|FP_D,    I4|I32	},
  {"movn.l",  "D,S,t",    0x46a00013, 0xffe0003f, WR_D|RD_S|RD_t|FP_D,    MX|SB1	},
-@@ -757,7 +814,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -776,7 +837,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"movt.l",  "X,Y,N",    0x46a10011, 0xffe3003f, WR_D|RD_S|RD_CC|FP_D,   MX|SB1	},
  {"movt.s",  "D,S,N",    0x46010011, 0xffe3003f, WR_D|RD_S|RD_CC|FP_S,   I4|I32	},
  {"movt.ps", "D,S,N",	0x46c10011, 0xffe3003f, WR_D|RD_S|RD_CC|FP_D,	I5	},
@@ -11677,7 +11611,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"ffs",     "d,v",	0x0000000a, 0xfc1f07ff,	WR_d|RD_s,		L1	},
  {"movz.d",  "D,S,t",    0x46200012, 0xffe0003f, WR_D|RD_S|RD_t|FP_D,    I4|I32	},
  {"movz.l",  "D,S,t",    0x46a00012, 0xffe0003f, WR_D|RD_S|RD_t|FP_D,    MX|SB1	},
-@@ -772,15 +829,20 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -791,15 +852,20 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"msgn.qh", "X,Y,Q",	0x78200000, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	MX	},
  {"msub.d",  "D,R,S,T",	0x4c000029, 0xfc00003f, RD_R|RD_S|RD_T|WR_D|FP_D, I4	},
  {"msub.s",  "D,R,S,T",	0x4c000028, 0xfc00003f, RD_R|RD_S|RD_T|WR_D|FP_S, I4	},
@@ -11699,7 +11633,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"mtc0",    "t,G,H",    0x40800000, 0xffe007f8, COD|RD_t|WR_C0|WR_CC,   I32     },
  {"mtc1",    "t,S",	0x44800000, 0xffe007ff,	COD|RD_t|WR_S|FP_S,	I1	},
  {"mtc1",    "t,G",	0x44800000, 0xffe007ff,	COD|RD_t|WR_S|FP_S,	I1	},
-@@ -792,8 +854,19 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -811,8 +877,19 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"mtc3",    "t,G",	0x4c800000, 0xffe007ff,	COD|RD_t|WR_C3|WR_CC,	I1	},
  {"mtc3",    "t,G,H",    0x4c800000, 0xffe007f8, COD|RD_t|WR_C3|WR_CC,   I32     },
  {"mtdr",    "t,G",	0x7080003d, 0xffe007ff,	COD|RD_t|WR_C0,		N5	},
@@ -11719,7 +11653,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"mul.d",   "D,V,T",	0x46200002, 0xffe0003f,	WR_D|RD_S|RD_T|FP_D,	I1	},
  {"mul.s",   "D,V,T",	0x46000002, 0xffe0003f,	WR_D|RD_S|RD_T|FP_S,	I1	},
  {"mul.ob",  "X,Y,Q",	0x78000030, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	MX|SB1	},
-@@ -811,6 +884,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -830,6 +907,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"mula.ob", "S,T[e]",	0x48000033, 0xfe2007ff,	WR_CC|RD_S|RD_T,	N54	},
  {"mula.ob", "S,k",	0x4bc00033, 0xffe007ff,	WR_CC|RD_S|RD_T,	N54	},
  {"mula.qh", "Y,Q",	0x78200033, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX	},
@@ -11727,7 +11661,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"mulhi",   "d,s,t",	0x00000258, 0xfc0007ff,	RD_s|RD_t|WR_HILO|WR_d,	N5	},
  {"mulhiu",  "d,s,t",	0x00000259, 0xfc0007ff,	RD_s|RD_t|WR_HILO|WR_d,	N5	},
  {"mull.ob", "Y,Q",	0x78000433, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D, MX|SB1	},
-@@ -839,8 +913,12 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -858,8 +936,12 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"mulsl.qh", "Y,Q",	0x78200432, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX	},
  {"mult",    "s,t",      0x00000018, 0xfc00ffff, RD_s|RD_t|WR_HILO|IS_M, I1	},
  {"mult",    "d,s,t",    0x00000018, 0xfc0007ff, RD_s|RD_t|WR_HILO|WR_d|IS_M, G1	},
@@ -11740,7 +11674,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"mulu",    "d,s,t",	0x00000059, 0xfc0007ff,	RD_s|RD_t|WR_HILO|WR_d,	N5	},
  {"neg",     "d,w",	0x00000022, 0xffe007ff,	WR_d|RD_t,		I1	}, /* sub 0 */
  {"negu",    "d,w",	0x00000023, 0xffe007ff,	WR_d|RD_t,		I1	}, /* subu 0 */
-@@ -872,7 +950,49 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -891,7 +973,49 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"ori",     "t,r,i",	0x34000000, 0xfc000000,	WR_t|RD_s,		I1	},
  {"pabsdiff.ob", "X,Y,Q",0x78000009, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	SB1	},
  {"pabsdiffc.ob", "Y,Q",	0x78000035, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	SB1	},
@@ -11790,7 +11724,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"pickf.ob", "X,Y,Q",	0x78000002, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	MX|SB1	},
  {"pickf.ob", "D,S,T",	0x4ac00002, 0xffe0003f,	WR_D|RD_S|RD_T,		N54	},
  {"pickf.ob", "D,S,T[e]",0x48000002, 0xfe20003f,	WR_D|RD_S|RD_T,		N54	},
-@@ -883,11 +1003,65 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -902,11 +1026,65 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"pickt.ob", "D,S,T[e]",0x48000003, 0xfe20003f,	WR_D|RD_S|RD_T,		N54	},
  {"pickt.ob", "D,S,k",	0x4bc00003, 0xffe0003f,	WR_D|RD_S|RD_T,		N54	},
  {"pickt.qh", "X,Y,Q",	0x78200003, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	MX	},
@@ -11856,7 +11790,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"rach.ob", "X",	0x7a00003f, 0xfffff83f,	WR_D|RD_MACC|FP_D,	MX|SB1	},
  {"rach.ob", "D",	0x4a00003f, 0xfffff83f,	WR_D,			N54	},
  {"rach.qh", "X",	0x7a20003f, 0xfffff83f,	WR_D|RD_MACC|FP_D,	MX	},
-@@ -939,6 +1113,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -958,6 +1136,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"rsqrt.d", "D,S",	0x46200016, 0xffff003f, WR_D|RD_S|FP_D,		I4	},
  {"rsqrt.ps","D,S",	0x46c00016, 0xffff003f, WR_D|RD_S|FP_D,		SB1	},
  {"rsqrt.s", "D,S",	0x46000016, 0xffff003f, WR_D|RD_S|FP_S,		I4	},
@@ -11864,7 +11798,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"rsqrt1.d",  "D,S",	0x4620001e, 0xffff003f,	WR_D|RD_S|FP_D,		M3D	},
  {"rsqrt1.ps", "D,S",	0x46c0001e, 0xffff003f,	WR_D|RD_S|FP_S,		M3D	},
  {"rsqrt1.s",  "D,S",	0x4600001e, 0xffff003f,	WR_D|RD_S|FP_S,		M3D	},
-@@ -967,13 +1142,15 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -986,13 +1165,15 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"sdc1",    "E,o(b)",	0xf4000000, 0xfc000000, SM|RD_T|RD_b|FP_D,	I2	},
  {"sdc1",    "T,A(b)",	0,    (int) M_SDC1_AB,	INSN_MACRO,		I2	},
  {"sdc1",    "E,A(b)",	0,    (int) M_SDC1_AB,	INSN_MACRO,		I2	},
@@ -11882,7 +11816,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"sdl",     "t,o(b)",	0xb0000000, 0xfc000000,	SM|RD_t|RD_b,		I3	},
  {"sdl",     "t,A(b)",	0,    (int) M_SDL_AB,	INSN_MACRO,		I3	},
  {"sdr",     "t,o(b)",	0xb4000000, 0xfc000000,	SM|RD_t|RD_b,		I3	},
-@@ -1028,7 +1205,9 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -1047,7 +1228,9 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"sltu",    "d,v,I",	0,    (int) M_SLTU_I,	INSN_MACRO,		I1	},
  {"sne",     "d,v,t",	0,    (int) M_SNE,	INSN_MACRO,		I1	},
  {"sne",     "d,v,I",	0,    (int) M_SNE_I,	INSN_MACRO,		I1	},
@@ -11892,7 +11826,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"sqrt.s",  "D,S",	0x46000004, 0xffff003f, WR_D|RD_S|FP_S,		I2	},
  {"sqrt.ps", "D,S",	0x46c00004, 0xffff003f, WR_D|RD_S|FP_D,		SB1	},
  {"srav",    "d,t,s",	0x00000007, 0xfc0007ff,	WR_d|RD_t|RD_s,		I1	},
-@@ -1056,6 +1235,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -1075,6 +1258,7 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"sub.qh",  "X,Y,Q",	0x7820000a, 0xfc20003f,	WR_D|RD_S|RD_T|FP_D,	MX	},
  {"suba.ob", "Y,Q",	0x78000036, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX|SB1	},
  {"suba.qh", "Y,Q",	0x78200036, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX	},
@@ -11900,7 +11834,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"subl.ob", "Y,Q",	0x78000436, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX|SB1	},
  {"subl.qh", "Y,Q",	0x78200436, 0xfc2007ff,	WR_MACC|RD_S|RD_T|FP_D,	MX	},
  {"subu",    "d,v,t",	0x00000023, 0xfc0007ff,	WR_d|RD_s|RD_t,		I1	},
-@@ -1086,8 +1266,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -1105,8 +1289,8 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"invalidate", "t,A(b)",0,    (int) M_SWR_AB,	INSN_MACRO,		I2	}, /* as swr */
  {"swxc1",   "S,t(b)",   0x4c000008, 0xfc0007ff, SM|RD_S|RD_t|RD_b,	I4	},
  {"sync",    "",		0x0000000f, 0xffffffff,	INSN_SYNC,		I2|G1	},
@@ -11911,7 +11845,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"synci",   "o(b)",	0x041f0000, 0xfc1f0000,	SM|RD_b,		I33	},
  {"syscall", "",		0x0000000c, 0xffffffff,	TRAP,			I1	},
  {"syscall", "B",	0x0000000c, 0xfc00003f,	TRAP,			I1	},
-@@ -1130,6 +1310,9 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -1149,6 +1333,9 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"trunc.w.d", "D,S",	0x4620000d, 0xffff003f, WR_D|RD_S|FP_D,		I2	},
  {"trunc.w.d", "D,S,x",	0x4620000d, 0xffff003f, WR_D|RD_S|FP_D,		I2	},
  {"trunc.w.d", "D,S,t",	0,    (int) M_TRUNCWD,	INSN_MACRO,		I1	},
@@ -11921,7 +11855,7 @@ index 228357a0c1..df7eb88d8a 100644
  {"trunc.w.s", "D,S",	0x4600000d, 0xffff003f,	WR_D|RD_S|FP_S,		I2	},
  {"trunc.w.s", "D,S,x",	0x4600000d, 0xffff003f,	WR_D|RD_S|FP_S,		I2	},
  {"trunc.w.s", "D,S,t",	0,    (int) M_TRUNCWS,	INSN_MACRO,		I1	},
-@@ -1147,6 +1330,132 @@ const struct mips_opcode mips_builtin_opcodes[] =
+@@ -1166,6 +1353,132 @@ const struct mips_opcode mips_builtin_opcodes[] =
  {"ush",     "t,A(b)",	0,    (int) M_USH_A,	INSN_MACRO,		I1	},
  {"usw",     "t,o(b)",	0,    (int) M_USW,	INSN_MACRO,		I1	},
  {"usw",     "t,A(b)",	0,    (int) M_USW_A,	INSN_MACRO,		I1	},

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# binutils-2.14.sh by Naomi Peori (naomi@peori.ca)
+# binutils-2.15.sh by Naomi Peori (naomi@peori.ca)
 
-BINUTILS_VERSION=2.14
+BINUTILS_VERSION=2.15
 ## Download the source code.
 SOURCE=http://ftpmirror.gnu.org/binutils/binutils-$BINUTILS_VERSION.tar.bz2
 wget --continue $SOURCE || { exit 1; }


### PR DESCRIPTION
## Description

With this PR we can udpate binutils to 2.15.

I have tested the whole ps2dev environment tools (toolchain, ps2sdk, gsKit, ps2sdk-ports, ps2-eth, ps2link, ps2-packer ...) all of them compile and generate proper executables.
Additionally, I have tried RetroArch and OPL and both also works.

```bash
$ ee-ld --version
GNU ld version 2.15
Copyright 2002 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License.  This program has absolutely no warranty.
```

Thanks